### PR TITLE
Fixed mutationobserver-shim to jest-dom

### DIFF
--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -488,19 +488,34 @@ export default {
         </p>
 
         <p>
-          Please install <code>mutationobserver-shim</code> because
-          react-hook-form use <code>MutationObserver</code> to detect inputs get
-          unmounted from the DOM.
+          Please install{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/testing-library/jest-dom"
+          >
+            @testing-library/jest-dom
+          </a>{" "}
+          with the latest version of <code>jest</code> because react-hook-form
+          use <code>MutationObserver</code> to detect inputs get unmounted from
+          the DOM.
         </p>
 
-        <CodeArea rawData={"npm install -D mutationobserver-shim"} />
+        <CodeArea rawData={"npm install -D @testing-library/jest-dom"} />
 
         <p>
           Create <code>setup.js</code> to import{" "}
-          <code>mutationobserver-shim</code>.
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/testing-library/jest-dom"
+          >
+            @testing-library/jest-dom
+          </a>
+          .
         </p>
         <CodeArea
-          rawData={'import "mutationobserver-shim";'}
+          rawData={'import "@testing-library/jest-dom";'}
           url="https://codesandbox.io/s/react-hook-form-unit-test-docs-ewpyt?file=/setup.js"
         />
 

--- a/src/data/jp/advanced.tsx
+++ b/src/data/jp/advanced.tsx
@@ -489,18 +489,32 @@ export default {
         <p>
           react-hook-form は DOM からアンマウントされた input
           要素を検出するために <code>MutationObserver</code> を使うため{" "}
-          <code>mutationobserver-shim</code>
-          をインストールしてください。
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/testing-library/jest-dom"
+          >
+            @testing-library/jest-dom
+          </a>{" "}
+          を <code>jest</code>{" "}
+          の最新バージョンとともにインストールしてください。
         </p>
 
-        <CodeArea rawData={"npm install -D mutationobserver-shim"} />
+        <CodeArea rawData={"npm install -D @testing-library/jest-dom"} />
 
         <p>
-          そして <code>mutationobserver-shim</code> をインポートするために{" "}
-          <code>setup.js</code> を作成してください。
+          そして{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/testing-library/jest-dom"
+          >
+            @testing-library/jest-dom
+          </a>{" "}
+          をインポートするために <code>setup.js</code> を作成してください。
         </p>
         <CodeArea
-          rawData={'import "mutationobserver-shim";'}
+          rawData={'import "@testing-library/jest-dom";'}
           url="https://codesandbox.io/s/react-hook-form-unit-test-docs-ewpyt?file=/setup.js"
         />
 


### PR DESCRIPTION
This is proposal.
I changed from `mutationobserver-shim` to `jest-dom`. The reason is please check this tweet https://twitter.com/TestingLib/status/1277219837849137153

If this change is make sense, please merge. I'm glad if you translate.