### PR TITLE
fix: Fix usage of setValue in V6 migration guide.

### DIFF
--- a/src/data/en/migrateV5ToV6.tsx
+++ b/src/data/en/migrateV5ToV6.tsx
@@ -277,7 +277,7 @@ export default (
       <CodeArea
         withOutCopy
         rawData={`- setValue('test', 'data')
-+ setError('test', 'data', { shouldDirty: true })
++ setValue('test', 'data', { shouldDirty: true })
 
 - setValue([ { test: "1", }, { test1: "2", } ])
 + [ { name: 'test', value: 'data' } ].forEach(({ name, value }) => setValue(name, value))


### PR DESCRIPTION
I'm assuming you meant to say `setValue` and not `setError`.

<img width="1060" alt="Screenshot 2020-07-01 at 3 20 23 PM" src="https://user-images.githubusercontent.com/5381764/86230351-9a8f2f00-bbae-11ea-9d4b-304677fb2cd6.png">
