### PR TITLE
Fixed code example in accessibility section of advanced page

### DIFF
--- a/src/components/codeExamples/accessibleCode.ts
+++ b/src/components/codeExamples/accessibleCode.ts
@@ -10,13 +10,15 @@ export default function App() {
       <input
         type="text"
         aria-invalid={errors.firstName ? "true" : "false"}
-        aria-describedby="firstNameError"
         name="firstName"
         ref={register({ required: true })}
       />
-      <span id="firstNameError" style={{ display: errors.firstName ? "block" : "none" }}>
-        This field is required
-      </span>
+      { errors.firstName && (
+          <span role="alert">
+            This field is required
+          </span>
+        )
+      }
 
       <input type="submit" />
     </form>

--- a/src/components/codeExamples/accessibleCodeFinal.ts
+++ b/src/components/codeExamples/accessibleCodeFinal.ts
@@ -13,33 +13,27 @@ export default function App() {
         id="name"
         {/* use aria-invalid to indicate field contain error */}
         aria-invalid={errors.name ? "true" : "false"}
-        {/* use aria-describedby to associate with error messages */}
-        aria-describedby="error-name-required error-name-maxLength"
         ref={register({ required: true, maxLength: 30 })}
       />
-      {/* the id field is used to associated with aria-describedby*/}
-      <span
-        role="alert"
-        id="error-name-required"
-        style={{
-          display: errors.name && errors.name.type === "required"
-            ? "block"
-            : "none"
-        }}
-      >
-        This is required
-      </span>
-      <span
-        role="alert"
-        id="error-name-maxLength"
-        style={{
-          display: errors.name && errors.name.type === "maxLength"
-            ? "block"
-            : "none"
-        }}
-      >
-        Max length exceeded
-      </span>
+      {/* use role="alert" to announce the error message */}
+      {
+        errors.name 
+        && errors.name.type === "required"
+        && (
+          <span role="alert">
+            This is required
+          </span>
+        )
+      }
+      {
+        errors.name 
+        && errors.name.type === "maxLength"
+        && (
+          <span role="alert">
+            Max length exceeded
+          </span>
+        )
+      }
       <input type="submit" />
     </form>
   );


### PR DESCRIPTION
I fixed code example in accessibility section.
Because `aria-description` is not read dynamically. And if you use `role="alert"` at initial rendering, screen reader unintended to read contents.

About `role="alert"`

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_alert_role
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-invalid_attribute