### PR TITLE
Separate CodeExamples for V5 vs. V6

### DIFF
--- a/src/components/Controller.tsx
+++ b/src/components/Controller.tsx
@@ -57,8 +57,8 @@ export default function Controller({
           <thead>
             <tr>
               <th>{generic.name[currentLanguage]}</th>
-              <th>{generic.type[currentLanguage]}</th>
-              <th>{generic.required[currentLanguage]}</th>
+              <th width="150px">{generic.type[currentLanguage]}</th>
+              <th width="90px">{generic.required[currentLanguage]}</th>
               <th>{generic.description[currentLanguage]}</th>
             </tr>
           </thead>

--- a/src/components/V5/ApiPageV5.tsx
+++ b/src/components/V5/ApiPageV5.tsx
@@ -27,7 +27,7 @@ import { navigate } from "@reach/router"
 import { useStateMachine } from "little-state-machine"
 import generic from "../../data/generic"
 import apiEn from "../../data/V5/en/api"
-import Controller from "../Controller"
+import ControllerV5 from "./ControllerV5"
 import ErrorMessage from "./ErrorMessageV5"
 import translateLink from "../logic/translateLink"
 import TabGroup from "../TabGroup"
@@ -959,7 +959,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
           <hr />
 
           <section ref={(ref) => (apiSectionsRef.current.ControllerRef = ref)}>
-            <Controller currentLanguage={currentLanguage} api={api} />
+            <ControllerV5 currentLanguage={currentLanguage} api={api} />
           </section>
 
           <hr />

--- a/src/components/V5/ControllerV5.tsx
+++ b/src/components/V5/ControllerV5.tsx
@@ -1,13 +1,13 @@
 import * as React from "react"
-import CodeArea from "./CodeArea"
-import controller from "./codeExamples/controller"
-import reactNativeController from "./codeExamples/reactNativeController"
-import generic from "../data/generic"
-import TabGroup from "./TabGroup"
-import typographyStyles from "../styles/typography.module.css"
-import tableStyles from "../styles/table.module.css"
-import controllerTs from "./codeExamples/controllerTs"
-import VideoList from "./VideoList"
+import CodeArea from "../CodeArea"
+import controller from "../codeExamples/controller"
+import reactNativeController from "../codeExamples/reactNativeController"
+import generic from "../../data/generic"
+import TabGroup from "../TabGroup"
+import typographyStyles from "../../styles/typography.module.css"
+import tableStyles from "../../styles/table.module.css"
+import controllerTs from "../codeExamples/controllerTs"
+import VideoList from "../VideoList"
 
 export default function Controller({
   currentLanguage,
@@ -68,14 +68,14 @@ export default function Controller({
       <TabGroup buttonLabels={["Web", "React Native"]}>
         <CodeArea
           rawData={controller}
-          url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+          url="https://codesandbox.io/s/react-hook-form-controller-v5-ii1vs"
           tsRawData={controllerTs}
-          tsUrl="https://codesandbox.io/s/react-hook-form-v6-controller-ts-4dpm9"
+          tsUrl="https://codesandbox.io/s/react-hook-form-controller-ts-v5-g2gmc"
         />
         <CodeArea
           rawData={reactNativeController}
           isExpo
-          url="https://snack.expo.io/@bluebill1049/react-hook-form-v6"
+          url="https://snack.expo.io/@bluebill1049/react-hook-form---controller"
         />
       </TabGroup>
     </>

--- a/src/components/V5/ControllerV5.tsx
+++ b/src/components/V5/ControllerV5.tsx
@@ -57,8 +57,8 @@ export default function Controller({
           <thead>
             <tr>
               <th>{generic.name[currentLanguage]}</th>
-              <th>{generic.type[currentLanguage]}</th>
-              <th>{generic.required[currentLanguage]}</th>
+              <th width="150px">{generic.type[currentLanguage]}</th>
+              <th width="90px">{generic.required[currentLanguage]}</th>
               <th>{generic.description[currentLanguage]}</th>
             </tr>
           </thead>

--- a/src/data/V5/en/api.tsx
+++ b/src/data/V5/en/api.tsx
@@ -1048,7 +1048,7 @@ onChange={{([ { checked } ]) => ({ checked })}}`}
             <p>
               Here is a{" "}
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/es/api.tsx
+++ b/src/data/V5/es/api.tsx
@@ -825,7 +825,7 @@ export default {
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/jp/api.tsx
+++ b/src/data/V5/jp/api.tsx
@@ -849,7 +849,7 @@ onChange={{([ { checked } ]) => ({ checked })}}`}
             <p>
               Here is a{" "}
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/kr/api.tsx
+++ b/src/data/V5/kr/api.tsx
@@ -819,7 +819,7 @@ onChange={{([ { checked } ]) => ({ checked })}}`}
             <p>
               여기에{" "}
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/pt/api.tsx
+++ b/src/data/V5/pt/api.tsx
@@ -834,7 +834,7 @@ export default {
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/ru/api.tsx
+++ b/src/data/V5/ru/api.tsx
@@ -1047,7 +1047,7 @@ React.useEffect(() => {
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/V5/zh/api.tsx
+++ b/src/data/V5/zh/api.tsx
@@ -799,7 +799,7 @@ export default {
             <p>
               这是一个
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v5-un45f"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1015,7 +1015,7 @@ React.useEffect(() => {
             </p>
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -1048,7 +1048,7 @@ React.useEffect(() => {
             <code>value</code>.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -1128,7 +1128,7 @@ React.useEffect(() => {
                 float: "right",
                 display: "flex",
               }}
-              url="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+              url="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
             />
           </td>
         </tr>

--- a/src/data/es/api.tsx
+++ b/src/data/es/api.tsx
@@ -699,7 +699,7 @@ export default {
             y <code>value</code> apoyos en el componente.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
                         as={<TextInput />} 
                         control={control} 
@@ -737,7 +737,7 @@ export default {
             <code>onBlur</code> y<code>value</code>.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
                           control={control} 
                           name="test" 
@@ -827,7 +827,7 @@ export default {
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/jp/api.tsx
+++ b/src/data/jp/api.tsx
@@ -710,7 +710,7 @@ export default {
             <code>value</code>をコンポーネントにプロップします。
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -748,7 +748,7 @@ export default {
             <code>value</code>。
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -853,7 +853,7 @@ validate: (value) => value === getValues('firstName');"
             <p>
               Here is a{" "}
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -991,7 +991,7 @@ React.useEffect(() => {
             </p>
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -1023,7 +1023,7 @@ React.useEffect(() => {
             사용하지 않는 외부 컴포넌트에 쉽게 적용할 수 있습니다.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -1104,7 +1104,7 @@ React.useEffect(() => {
                 float: "right",
                 display: "flex",
               }}
-              url="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+              url="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
             />
           </td>
         </tr>

--- a/src/data/pt/api.tsx
+++ b/src/data/pt/api.tsx
@@ -708,7 +708,7 @@ export default {
             e <code>value</code> adota o componente.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -745,7 +745,7 @@ export default {
             <code>onChange</code>, <code>onBlur</code> e <code>value</code>.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -835,7 +835,7 @@ validate: (value) => value === getValues('firstName');"
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/ru/api.tsx
+++ b/src/data/ru/api.tsx
@@ -985,7 +985,7 @@ React.useEffect(() => {
             <code>value</code> вставляется в компонент.
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -1023,7 +1023,7 @@ React.useEffect(() => {
             <code>onBlur</code> и <code>value</code>..
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -1122,7 +1122,7 @@ validate: (value) => value === getValues('firstName');"
             </p>
             <p>
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/src/data/zh/api.tsx
+++ b/src/data/zh/api.tsx
@@ -690,7 +690,7 @@ export default {
             <code>value</code>属性插入组件。
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller 
   as={<TextInput />} 
   control={control} 
@@ -727,7 +727,7 @@ export default {
             。
             <CodeArea
               withOutCopy
-              url="https://codesandbox.io/s/react-hook-form-v6-controller-qsd8r"
+              url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
   control={control} 
   name="test" 
@@ -824,7 +824,7 @@ validate: (value) => value === getValues('firstName');"
             <p>
               这是一个
               <a
-                href="https://codesandbox.io/s/react-hook-form-controller-auto-focus-5tru5"
+                href="https://codesandbox.io/s/react-hook-form-controllerautofocus-v6-eeo66"
                 target="_blank"
                 rel="noopener noreferrer"
               >


### PR DESCRIPTION
This PR fixes #324. (or at least address some of what was discussed there)
- Separate Code for V5 vs. V6 controller (I don't love how this is done [pure code duplication rn]), Am postulating a better structure)
- A bunch of tweaked CodeSanbox's