### PR TITLE
docs(Migration): fix controller section typo (#340)

### DIFF
--- a/src/data/en/migrateV5ToV6.tsx
+++ b/src/data/en/migrateV5ToV6.tsx
@@ -113,7 +113,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/es/migrateV5ToV6.tsx
+++ b/src/data/es/migrateV5ToV6.tsx
@@ -116,7 +116,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/jp/migrateV5ToV6.tsx
+++ b/src/data/jp/migrateV5ToV6.tsx
@@ -113,7 +113,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/kr/migrateV5ToV6.tsx
+++ b/src/data/kr/migrateV5ToV6.tsx
@@ -112,7 +112,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/pt/migrateV5ToV6.tsx
+++ b/src/data/pt/migrateV5ToV6.tsx
@@ -113,7 +113,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/ru/migrateV5ToV6.tsx
+++ b/src/data/ru/migrateV5ToV6.tsx
@@ -114,7 +114,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}

--- a/src/data/zh/migrateV5ToV6.tsx
+++ b/src/data/zh/migrateV5ToV6.tsx
@@ -113,7 +113,7 @@ export default (
 -   valueName="textValue"
 - />
 
-+ <Controllername="test"
++ <Controller name="test"
 +   render={({ onChange, onBlur, value }) => {
 +     <Input
 +       valueName={value}


### PR DESCRIPTION
Attribute `name` was concatenated with `<Controller`, this PR fixes the typo.