### PR TITLE
fix: css declaration

### DIFF
--- a/Global.d.ts
+++ b/Global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.module.css"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/18083815/86426304-e6aab280-bd19-11ea-84a4-7cb4b44befe8.png)

fix css module type declaration error based on https://stackoverflow.com/questions/41336858/how-to-import-css-modules-with-typescript-react-and-webpack/51536973#51536973