### PR TITLE
chore: enhance get-start chinese

### DIFF
--- a/src/data/zh/getStarted.tsx
+++ b/src/data/zh/getStarted.tsx
@@ -8,35 +8,35 @@ export default {
   title: "起步",
   header: {
     title: "起步",
-    description: "React Hook Form 让表单验证变得简单.",
+    description: "React Hook Form 简化表单校验.",
   },
   video: {
     title: "视频教程",
-    description: `在本视频教程中，我演示了使用React Hook Form的基本用法和概念。（不好意思是英文的）`,
+    description: `在本视频教程中，我演示了使用React Hook Form的基本用法和概念。`,
   },
   install: {
     linkTitle: "安装",
-    title: "快速启动",
-    description: `安装React Hook Form只需要一个命令，你就可以开始了。`,
+    title: "快速入门",
+    description: `仅需一个命令，即可尝试React Hook Form。`,
   },
   example: {
     title: "例子",
     description: `以下代码将演示基本用法:`,
   },
   register: {
-    title: "注册表格",
+    title: "注册表单项",
     description: (
       <>
         <p>
-          React Hook Form的一个关键概念是将您不受控制的组件
+          React Hook Form的一个关键概念是将非受控组件
           <strong>注册</strong>
-          到Hook中，从而使其价值得到验证并收集来以供提交。
+          到Hook中，从而在表单校验和提交时可以获取到它的值。
         </p>
 
         <p>
-          <b className={typographyStyles.note}>注意：</b>每个表格都需要有一个
-          <strong>独特</strong>
-          的名称作为注册过程的密钥
+          <b className={typographyStyles.note}>注意：</b>每个表单项都需要
+          <strong>唯一</strong>
+          的<code>name</code>作为注册的键
         </p>
 
         <p>
@@ -45,29 +45,28 @@ export default {
           <code>{`register({ name: 'test' }, { required: true })`}</code>
           或使用
           <Link to="/api#Controller">Controller</Link>
-          来包装您的组件。您还可以在
-          <Link to="/api/#ReactNative">React Native</Link>部分阅读更多内容。
+          来包装并注册你的组件。
         </p>
       </>
     ),
   },
   applyValidation: {
-    title: "应用验证",
+    title: "校验",
     description: (currentLanguage) => (
       <>
         <p>
-          React Hook Form 通过与现有的
+          React Hook Form 结合了
           <a
             href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Form_validation"
             target="_blank"
             rel="noopener noreferrer"
           >
-            HTML标准表单验证
+            HTML标准表单校验
           </a>
-          进行对齐，使表单验证变得简单。
+          ，使表单校验变得简单。
         </p>
 
-        <p>支持的验证规则列表:</p>
+        <p>支持的校验规则列表:</p>
         <ul>
           <li>required</li>
           <li>min</li>
@@ -78,9 +77,9 @@ export default {
           <li>validate</li>
         </ul>
         <p>
-          您可以在
+          你可以在
           <Link to={translateLink("api#register", currentLanguage)}>
-            注册部分(register)
+            注册表单项(register)
           </Link>
           阅读每个规则的更多细节。
         </p>
@@ -88,10 +87,10 @@ export default {
     ),
   },
   adapting: {
-    title: "调整您现有的表格",
+    title: "适配已有表单",
     description: (
       <>
-        处理您现有表单很简单。 重要的步骤是将表单组件的<code>ref</code>注册。
+        处理已有表单很简单。关键步骤是将<code>register</code>应用到已有组件的<code>ref</code>中。
       </>
     ),
   },
@@ -100,7 +99,7 @@ export default {
     description: (
       <p>
         React Hook
-        Form支持和拥护不受控制的组件和HTML输入，但是很难避免使用外部受控组件，比如说
+        Form拥抱非受控组件和HTML输入框，但是很难避免使用外部受控组件，比如
         <a
           target="_blank"
           rel="noopener noreferrer"
@@ -124,58 +123,94 @@ export default {
         >
           Material-UI
         </a>
-        ，因此我们建立了一个包装组件:{" "}
+        ，因此我们提供了一个包装组件:{" "}
         <Link to="/api#Controller">Controller</Link>{" "}
-        来简化集成过程，同时仍然可以自由地使用自定义register满足您的需求。
+        来简化集成过程，同时仍然可以自由地使用自定义register满足你的需求。
       </p>
+      <p>
+          了解更多 <Link to={translateLink("api#Controller", currentLanguage)}>Controller</Link>{" "}
+          组件的内容.
+        </p>
     ),
   },
   workWithUI: {
     title: "使用UI库",
     description: (currentLanguage) => (
       <>
-        <p>React Hook Form 让外部UI组件库集成变得简单。</p>
+        <p>React Hook Form 与第三方UI组件库一起使用非常方便。你可以观看下方视频</p>
+        <VideoList
+          lists={[
+            {
+              url: "https://www.youtube.com/watch?v=PquWexbGcVc",
+              title: "如何在 Material UI 中使用 React-Hook-Form",
+            },
+            {
+              url: "https://www.youtube.com/watch?v=0nDGeQKLFjo",
+              title: "React Hook Form - React 表单第二章",
+            },
+          ]}
+          play
+        />
+
         <p>
-          <b className={typographyStyles.note}>注意:</b> 大多数UI库都会将内部的
-          <code>innerRef</code>或者
-          <code>Ref</code>
-          公开给与注册
-          <code>
-            <Link to={translateLink("api#register", currentLanguage)}>
-              register
-            </Link>
-          </code>
-          。但是，对于像react-selector和
-          react-datepicker这样更复杂的组件并且不提供<code>Ref</code>
-          ，您可以通过<code>register</code>在<code>useEffect</code>
-          中实现，再通过运用
+          <b className={typographyStyles.note}>使用方法 1:</b> 最好的方式是检查你想要使用的组件是否暴露了 <code>ref</code>{" "}
+            可以用于{" "}
+            <code>
+              <Link to={translateLink("api#register", currentLanguage)}>
+                register
+              </Link>
+            </code>
+            。例如: Material-UI 的 <code>TextField</code> 的 props 就包含了{" "}
+            <code>inputRef</code> 。 你可以直接将{" "}
+            <code>register</code> 传递给它。
+        </p>
+        <p>
+          <code>{'<TextField ref={register} name="FirstName"/>'}</code>
+        </p>
+        <p>
+          <b className={typographyStyles.note}>使用方法 2:</b> 有时组件没有暴露 prop 用来注册, 例如{" "}
+          <code>react-select</code> 或者 <code>react-datepicker</code>。
+        </p>
+        <p>
+          第二种方法是使用{" "}
+          <Link to={translateLink("/api#Controller", currentLanguage)}>Controller</Link> 包裹组件，他会帮你处理注册过程。
+        </p>
+        <CodeArea
+          rawData={uiLibraryHookInput}
+          url="https://codesandbox.io/s/react-hook-form-with-ui-library-lg33x"
+          tsRawData={uiLibraryHookInputTs}
+          tsUrl="https://codesandbox.io/s/react-hook-form-with-ui-library-ts-dkjbf"
+        />
+        <p>
+          <b className={typographyStyles.note}>使用方法 3:</b> 最后我们可以通过{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://reactjs.org/docs/hooks-effect.html"
+          >
+            useEffect
+          </a>{" "}
+          Hook 自定义注册并更新表单项的值。{" "}
           <code>
             <Link to={translateLink("api#setValue", currentLanguage)}>
               setValue
             </Link>
           </code>
-          更新它的值。
-        </p>
-        <p>
-          <b className={typographyStyles.note}>注意:</b>
-          我们还制作了一个包装器组件
-          <Link to="/api#Controller">Controller</Link>
-          ，以帮助您的自定义注册表格过程。
         </p>
       </>
     ),
   },
   globalState: {
-    title: "整合表单状态",
-    description: `React Hook Form不要求你有一个状态(state)管理来存储你的数据，但你可以很容易地与任何一个集成。`,
+    title: "集成全局状态",
+    description: `React Hook Form不需要类似 Redux 的状态管理工具来存储状态，但你可以很容易地与任何一个集成。`,
   },
   reactNative: {
     title: "React Native",
     description: (
       <p>
-        您将从受控制的组件中获得相同的性能增强。 但是，有一些与React
-        Native不兼容的Api（与web和native的API差异）。
-        您将不得不使用手动注册，如下面的示例所示。
+        你将从受控组件中获得相同的性能增强。 但是，有一些与React
+        Native不兼容的Api（出于web和native的API差异）。
+        你将不得不使用<code>Controller</code> 或 <b>custom register</b>，如下面的示例所示。
       </p>
     ),
   },
@@ -184,17 +219,17 @@ export default {
     description: (
       <p>
         React Hook Form是使用<code>Typescript</code>
-        构建的，因此您可以定义一个表单数据<code>FormData</code>
-        类型来支持表单值。
+        构建的，因此你可以定义一个<code>FormData</code>类型
+        来表达表单值。
       </p>
     ),
   },
   errors: {
     title: "处理错误",
-    description: <>React Hook Form提供了一个错误对象，用于显示表单中的错误。</>,
+    description: <>React Hook Form提供了一个<code>errors</code>对象显示表单中的错误。</>,
   },
   schema: {
-    title: "架构验证",
+    title: "数据格式校验",
     description: (
       <>
         <p>
@@ -222,10 +257,9 @@ export default {
           >
             Joi
           </a>
-          进行基于模式的表单验证，您可以在<a href="/api#useForm">useForm</a>
-          其中通过
-          <code>validationSchema</code>将表单用作可选配置。 React Hook
-          Form将根据模式验证您的输入数据，并返回<a href="/api#errors">错误</a>
+          进行基于数据格式的表单校验，你可以将<code>schema</code>用作可选配置传给<Link to={translateLink("/api#useForm", currentLanguage)}>useForm</Link>
+          。 React Hook
+          Form将根据数据格式校验你的输入数据，并返回<Link to={translateLink("/api#errors", currentLanguage)}>错误</Link>
           或有效结果。
         </p>
       </>
@@ -234,14 +268,14 @@ export default {
       <>
         <p>
           <b className={typographyStyles.note}>步骤1:</b> 将<code>Yup</code>
-          安装到您的项目中。
+          安装到你的项目中。
         </p>
       </>
     ),
     step2: (
       <p>
         <b className={typographyStyles.note}>步骤2:</b>{" "}
-        准备您的架构以进行验证和注册 输入到React Hook Form.
+        准备你的数据格式以进行校验并注册到React Hook Form.
       </p>
     ),
   },

--- a/src/data/zh/getStarted.tsx
+++ b/src/data/zh/getStarted.tsx
@@ -3,6 +3,12 @@ import code from "../../components/codeExamples/defaultExample"
 import { Link } from "@reach/router"
 import translateLink from "../../components/logic/translateLink"
 import typographyStyles from "../../styles/typography.module.css"
+import CodeArea from "../../components/CodeArea"
+import {
+  uiLibraryHookInput,
+  uiLibraryHookInputTs,
+} from "../../components/codeExamples/getStarted"
+import VideoList from "../../components/VideoList"
 
 export default {
   title: "起步",
@@ -35,8 +41,7 @@ export default {
 
         <p>
           <b className={typographyStyles.note}>注意：</b>每个表单项都需要
-          <strong>唯一</strong>
-          的<code>name</code>作为注册的键
+          <strong>唯一</strong>的<code>name</code>作为注册的键
         </p>
 
         <p>
@@ -90,54 +95,62 @@ export default {
     title: "适配已有表单",
     description: (
       <>
-        处理已有表单很简单。关键步骤是将<code>register</code>应用到已有组件的<code>ref</code>中。
+        处理已有表单很简单。关键步骤是将<code>register</code>应用到已有组件的
+        <code>ref</code>中。
       </>
     ),
   },
   controlledInput: {
     title: "受控输入",
-    description: (
-      <p>
-        React Hook
-        Form拥抱非受控组件和HTML输入框，但是很难避免使用外部受控组件，比如
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/JedWatson/react-select"
-        >
-          React-Select
-        </a>
-        ,{" "}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://github.com/ant-design/ant-design"
-        >
-          AntD
-        </a>{" "}
-        和{" "}
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href="https://material-ui.com/"
-        >
-          Material-UI
-        </a>
-        ，因此我们提供了一个包装组件:{" "}
-        <Link to="/api#Controller">Controller</Link>{" "}
-        来简化集成过程，同时仍然可以自由地使用自定义register满足你的需求。
-      </p>
-      <p>
-          了解更多 <Link to={translateLink("api#Controller", currentLanguage)}>Controller</Link>{" "}
+    description: (currentLanguage) => (
+      <>
+        <p>
+          React Hook
+          Form拥抱非受控组件和HTML输入框，但是很难避免使用外部受控组件，比如
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/JedWatson/react-select"
+          >
+            React-Select
+          </a>
+          ,{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/ant-design/ant-design"
+          >
+            AntD
+          </a>{" "}
+          和{" "}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://material-ui.com/"
+          >
+            Material-UI
+          </a>
+          ，因此我们提供了一个包装组件:{" "}
+          <Link to="/api#Controller">Controller</Link>{" "}
+          来简化集成过程，同时仍然可以自由地使用自定义register满足你的需求。
+        </p>
+        <p>
+          了解更多{" "}
+          <Link to={translateLink("api#Controller", currentLanguage)}>
+            Controller
+          </Link>{" "}
           组件的内容.
         </p>
+      </>
     ),
   },
   workWithUI: {
     title: "使用UI库",
     description: (currentLanguage) => (
       <>
-        <p>React Hook Form 与第三方UI组件库一起使用非常方便。你可以观看下方视频</p>
+        <p>
+          React Hook Form 与第三方UI组件库一起使用非常方便。你可以观看下方视频
+        </p>
         <VideoList
           lists={[
             {
@@ -153,27 +166,30 @@ export default {
         />
 
         <p>
-          <b className={typographyStyles.note}>使用方法 1:</b> 最好的方式是检查你想要使用的组件是否暴露了 <code>ref</code>{" "}
-            可以用于{" "}
-            <code>
-              <Link to={translateLink("api#register", currentLanguage)}>
-                register
-              </Link>
-            </code>
-            。例如: Material-UI 的 <code>TextField</code> 的 props 就包含了{" "}
-            <code>inputRef</code> 。 你可以直接将{" "}
-            <code>register</code> 传递给它。
+          <b className={typographyStyles.note}>使用方法 1:</b>{" "}
+          最好的方式是检查你想要使用的组件是否暴露了 <code>ref</code> 可以用于{" "}
+          <code>
+            <Link to={translateLink("api#register", currentLanguage)}>
+              register
+            </Link>
+          </code>
+          。例如: Material-UI 的 <code>TextField</code> 的 props 就包含了{" "}
+          <code>inputRef</code> 。 你可以直接将 <code>register</code> 传递给它。
         </p>
         <p>
           <code>{'<TextField ref={register} name="FirstName"/>'}</code>
         </p>
         <p>
-          <b className={typographyStyles.note}>使用方法 2:</b> 有时组件没有暴露 prop 用来注册, 例如{" "}
-          <code>react-select</code> 或者 <code>react-datepicker</code>。
+          <b className={typographyStyles.note}>使用方法 2:</b> 有时组件没有暴露
+          prop 用来注册, 例如 <code>react-select</code> 或者{" "}
+          <code>react-datepicker</code>。
         </p>
         <p>
           第二种方法是使用{" "}
-          <Link to={translateLink("/api#Controller", currentLanguage)}>Controller</Link> 包裹组件，他会帮你处理注册过程。
+          <Link to={translateLink("/api#Controller", currentLanguage)}>
+            Controller
+          </Link>{" "}
+          包裹组件，他会帮你处理注册过程。
         </p>
         <CodeArea
           rawData={uiLibraryHookInput}
@@ -209,8 +225,8 @@ export default {
     description: (
       <p>
         你将从受控组件中获得相同的性能增强。 但是，有一些与React
-        Native不兼容的Api（出于web和native的API差异）。
-        你将不得不使用<code>Controller</code> 或 <b>custom register</b>，如下面的示例所示。
+        Native不兼容的Api（出于web和native的API差异）。 你将不得不使用
+        <code>Controller</code> 或 <b>custom register</b>，如下面的示例所示。
       </p>
     ),
   },
@@ -219,18 +235,21 @@ export default {
     description: (
       <p>
         React Hook Form是使用<code>Typescript</code>
-        构建的，因此你可以定义一个<code>FormData</code>类型
-        来表达表单值。
+        构建的，因此你可以定义一个<code>FormData</code>类型 来表达表单值。
       </p>
     ),
   },
   errors: {
     title: "处理错误",
-    description: <>React Hook Form提供了一个<code>errors</code>对象显示表单中的错误。</>,
+    description: (
+      <>
+        React Hook Form提供了一个<code>errors</code>对象显示表单中的错误。
+      </>
+    ),
   },
   schema: {
     title: "数据格式校验",
-    description: (
+    description: (currentLanguage) => (
       <>
         <p>
           React Hook Form支持使用
@@ -257,9 +276,13 @@ export default {
           >
             Joi
           </a>
-          进行基于数据格式的表单校验，你可以将<code>schema</code>用作可选配置传给<Link to={translateLink("/api#useForm", currentLanguage)}>useForm</Link>
-          。 React Hook
-          Form将根据数据格式校验你的输入数据，并返回<Link to={translateLink("/api#errors", currentLanguage)}>错误</Link>
+          进行基于数据格式的表单校验，你可以将<code>schema</code>
+          用作可选配置传给
+          <Link to={translateLink("/api#useForm", currentLanguage)}>
+            useForm
+          </Link>
+          。 React Hook Form将根据数据格式校验你的输入数据，并返回
+          <Link to={translateLink("/api#errors", currentLanguage)}>错误</Link>
           或有效结果。
         </p>
       </>


### PR DESCRIPTION
Enhance and sync get-start part chinese version. Major change points includes: 

- chinese terms
   - *Uncontrolled component*  `不受控制的组件` to `非受控组件` based on react chinese doc and chinese community usage.
    -  *validation* `验证` to `校验` based on ant-design usage.
    - *external ui libraries* `外部ui组件库` to `第三方ui组件库` based on chinese community usage.

- Sync current en docs, and correct some links with `translateLink`.
- change something to make it easier to understand in chinese.






