### PR TITLE
Improve performance in api page

### DIFF
--- a/src/components/ApiRefTable.module.css
+++ b/src/components/ApiRefTable.module.css
@@ -12,6 +12,7 @@
 .fieldset > label {
   padding-bottom: 15px;
   display: block;
+  cursor: pointer;
 }
 
 .fieldset > label:nth-child(2) {

--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -16,9 +16,12 @@ export default function ApiRefTable({
   currentLanguage: string
 }) {
   const [isStandard, toggleOption] = React.useState(true)
+  const highlightContainer = React.useRef<HTMLTableElement | null>(null)
 
   React.useEffect(() => {
-    Prism.highlightAll()
+    if (highlightContainer.current) {
+      Prism.highlightAllUnder(highlightContainer.current)
+    }
   }, [isStandard])
 
   return (
@@ -97,7 +100,7 @@ export default function ApiRefTable({
       </fieldset>
 
       <div className={tableStyles.tableWrapper}>
-        <table className={tableStyles.table}>
+        <table className={tableStyles.table} ref={highlightContainer}>
           <tbody>
             <tr>
               <th


### PR DESCRIPTION
I fixed css and performance with Register Options feature in API page.

- I added `cursor: pointer;`
- I replaced from `Prism.highlightAll` to `Prism.highlightAllUnder` because it is too late when I clicked Register Options.