### PR TITLE
improved render-blocking

### DIFF
--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import copyClipBoard from "./utils/copyClipBoard"
 import { useStateMachine } from "little-state-machine"
 import generic from "../data/generic"
+import Prism from "prismjs"
 import styles from "./CodeArea.module.css"
 
 export const CodeSandBoxLink = ({
@@ -69,6 +70,7 @@ export default function CodeArea({
       (tsRawData && ToggleTypes.ts) ||
       ToggleTypes.types
   )
+  const codeAreaRef = React.useRef<HTMLDivElement | null>(null)
 
   const getData = () => {
     switch (currentType) {
@@ -83,6 +85,15 @@ export default function CodeArea({
 
   const { currentLanguage } =
     language && language.currentLanguage ? language : { currentLanguage: "en" }
+
+  React.useEffect(() => {
+    const highlight = async () => {
+      if (codeAreaRef.current) {
+        Prism.highlightAllUnder(codeAreaRef.current)
+      }
+    }
+    highlight()
+  }, [])
 
   return (
     <section
@@ -144,7 +155,7 @@ export default function CodeArea({
         )}
       </div>
 
-      <div className={styles.wrapper}>
+      <div className={styles.wrapper} ref={codeAreaRef}>
         <pre style={style} className="raw-code">
           <code
             className={`language-javascript ${

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,6 +1,5 @@
 import * as React from "react"
 import { Animate } from "react-simple-animate"
-import Prism from "prismjs"
 import { useStateMachine } from "little-state-machine"
 import Nav from "./Nav"
 import "./layout.css"
@@ -33,7 +32,6 @@ const Layout = (props: {
       document.querySelector("body").classList.remove("light")
     }
 
-    Prism.highlightAll()
     return () => window.removeEventListener("scroll", scrollHandler)
   }, [lightMode])
 


### PR DESCRIPTION
Related to #350, I fixed render-blocking in `Layout` components. To fix this, I move `Prism.highlightAll` to `CodeArea` component and I replaced to `Prism.highlightAllUnder`. This problem occur when it toggle light mode and dark mode or it navigate another page.