### PR TITLE
fix: language select state

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -102,7 +102,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
 
             navigate(getNavLink(url, selectedLanguage))
           }}
-          defaultValue={currentLanguage}
+          value={currentLanguage}
         >
           <option value="en">English</option>
           <option value="zh">简体中文</option>


### PR DESCRIPTION
sync select state with location.

Steps to reproduce bug.
- click  https://react-hook-form.com/api
- click useForm v5 and select chinese
- click v6 then navigate to english api page but select value not update because of defaultValue props.