### PR TITLE
Fix advanced-usage path on ApiPage

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -1017,7 +1017,7 @@ const { register } = useForm<FormInputs>({
             <button
               className={buttonStyles.primaryButton}
               onClick={() => {
-                navigate(translateLink("advanced-usage", currentLanguage))
+                navigate(translateLink("/advanced-usage", currentLanguage))
               }}
               style={{ margin: "40px auto" }}
             >


### PR DESCRIPTION
Clicking the link when the current location is something like `/api/#formState` would result in a 404 page `/api/advanced-usage`