### PR TITLE
Basic lighthouse setup

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,22 @@
+name: Test Lighthouse Stats
+
+on: [pull_request]
+
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: npm install, build
+        run: |
+          npm install
+          npm run build
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@0.4.x
+          lhci autorun

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  ci: {
+    upload: {
+      target: 'temporary-public-storage',
+    },
+    assert: {
+      assertions: {
+        "first-contentful-paint": ["error", {"maxNumericValue": 2500}]
+      },
+    }
+  },
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.0.1",
   "author": "beier luo",
   "engines": {
-    "node": "12.x"
+    "node": "14.x"
   },
   "dependencies": {
     "@hookform/devtools": "2.0.0-beta.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "6.0.1",
   "author": "beier luo",
   "engines": {
-    "node": "14.x"
+    "node": "12.x"
   },
   "dependencies": {
     "@hookform/devtools": "2.0.0-beta.1",


### PR DESCRIPTION
This is the most basic setup for [lighthouse-ci](https://github.com/GoogleChrome/lighthouse-ci). It runs a lighthouse check, creates a temporary report (saved for 7 days), and ensures the first-contentful-paint is not any slower then 2.5s.
To add in the future:
	- More assertions (They have a list of [recommended assertions](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/getting-started.md#add-assertions) but I want to get the base setup working before adding more.
	- [nice configuration](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/getting-started.md#github-status-checks) with github 
	- Create [our own server](https://github.com/GoogleChrome/lighthouse-ci/blob/master/docs/getting-started.md#the-lighthouse-ci-server) to check lighthouse stats. This would be awesome, but would require some careful setup. I'll leave it to last.

Question: Is there a way to test that this will work before merging the PR? Idk if it will trigger a actions run when i submit the PR. To be seen I guess.