### PR TITLE
Simplify useEffect and fix navigation highlighting

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -163,8 +163,8 @@ function ApiPage({ formData, defaultLang, api }: Props) {
     ControllerRef: null,
     ErrorMessageRef: null,
     useFormContextRef: null,
-    useFieldArrayRef: null,
     useWatchRef: null,
+    useFieldArrayRef: null,
   })
   copyFormData.current = formData
 
@@ -207,34 +207,26 @@ function ApiPage({ formData, defaultLang, api }: Props) {
     if (isUnmount.current) return
     try {
       const observer = new IntersectionObserver(
-        (entries) => {
-          let index = 0
-          const allTops = []
-          entries.forEach(() => {
-            try {
-              for (const key in apiSectionsRef.current) {
-                const { top } = apiSectionsRef.current[
-                  key
-                ].getBoundingClientRect()
-                allTops.push(top)
-                index++
+        () => {
+          const allTops = Object.keys(apiSectionsRef.current).reduce(
+            (acc, cur) => {
+              if (apiSectionsRef.current[cur]) {
+                acc.push(
+                  apiSectionsRef.current[cur].getBoundingClientRect().top
+                )
               }
-            } catch {}
-          })
+              return acc
+            },
+            []
+          )
 
-          index = 0
-          let foundIndex = 0
-          let temp
-
-          for (const top of allTops) {
-            if (temp === undefined || Math.abs(top) < Math.abs(temp)) {
-              temp = top
-              foundIndex = index
-            }
-            index++
-          }
-
-          setActiveIndex(foundIndex)
+          const smallestAbsoluteTop = Math.min(
+            ...allTops.map((top) => Math.abs(top))
+          )
+          const smallestAbsoluteTopIndex = allTops.findIndex(
+            (top) => Math.abs(top) === smallestAbsoluteTop
+          )
+          setActiveIndex(smallestAbsoluteTopIndex)
         },
         {
           rootMargin: "100px",


### PR DESCRIPTION
This PR fixes Issue #375.

- The real issue is that the refs were declared in an improper order... ([Lines 166 and 167](https://github.com/react-hook-form/documentation/compare/master...pmaier983:fix/navigation-highlighting?expand=1#diff-8e2137ec74d914a55499d50c2858f9bcL166)) but to find this I first refactored the entire highlighting useEffect to be more functionally coded. What I'm saying is, this PR could be a 2-liner if the refactoring is not up to snuff.