### PR TITLE
Remove charged terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Here is a quick guide to doing code contributions to the library.
 
 1. Fork and clone the repo to your local machine `git clone https://github.com/YOUR_GITHUB_USERNAME/website.git`
 
-2. Create a new branch from `master` with a meaningful name for a new feature or an issue you want to work on: `git checkout -b your-meaningful-branch-name`
+2. Create a new branch from `main` with a meaningful name for a new feature or an issue you want to work on: `git checkout -b your-meaningful-branch-name`
 
 3. Install packages by running:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
     <p align="center">
         <a href="https://react-hook-form.com" title="React Hook Form - Simple React forms validation">
-            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/master/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
+            <img src="https://raw.githubusercontent.com/bluebill1049/react-hook-form/main/website/logo.png" alt="React Hook Form Logo - React hook custom hook for form validation" width="300px" />
         </a>
     </p>
 </div>
@@ -22,7 +22,7 @@ Thanks goes to all our backers! [[Become a backer](https://opencollective.com/re
 
 ## Contributors
 
-Thanks goes to these wonderful people. [[Become a contributor](https://github.com/react-hook-form/react-hook-form/blob/master/CONTRIBUTING.md)].
+Thanks goes to these wonderful people. [[Become a contributor](https://github.com/react-hook-form/react-hook-form/blob/main/CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -217,7 +217,7 @@ function SideMenu({
                 <code className={styles.code}>{`</>`}</code>
                 <a
                   rel="noopener noreferrer"
-                  href="https://github.com/bluebill1049/react-hook-form/tree/master/examples"
+                  href="https://github.com/bluebill1049/react-hook-form/tree/main/examples"
                   target="_blank"
                 >
                   {generic.codeExample[currentLanguage]}

--- a/src/components/logic/getEditLink.tsx
+++ b/src/components/logic/getEditLink.tsx
@@ -1,5 +1,5 @@
 const preFix =
-  "https://github.com/react-hook-form/documentation/edit/master/src/data/"
+  "https://github.com/react-hook-form/documentation/edit/main/src/data/"
 
 export const getEditLink = (
   currentLanguage: string,

--- a/src/data/V5/en/api.tsx
+++ b/src/data/V5/en/api.tsx
@@ -262,7 +262,7 @@ export default {
         input name as <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           Check out the Field Array example

--- a/src/data/V5/es/api.tsx
+++ b/src/data/V5/es/api.tsx
@@ -268,7 +268,7 @@ export default {
         un nombre de input como <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="Ejemplo de Field Array"
         >
           Consulta el ejemplo de Field Array

--- a/src/data/V5/jp/api.tsx
+++ b/src/data/V5/jp/api.tsx
@@ -266,7 +266,7 @@ export default {
         <code>name[index]</code> のように割り当てることができます。
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           フィールド配列の例をご覧ください

--- a/src/data/V5/kr/api.tsx
+++ b/src/data/V5/kr/api.tsx
@@ -260,7 +260,7 @@ export default {
         name을 지정할 수 있습니다.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           Field Array 예제를 확인하세요.

--- a/src/data/V5/pt/api.tsx
+++ b/src/data/V5/pt/api.tsx
@@ -263,7 +263,7 @@ export default {
         assinar um campo name com <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           Confira o exemplo com campo Matriz(Array)

--- a/src/data/V5/ru/api.tsx
+++ b/src/data/V5/ru/api.tsx
@@ -264,7 +264,7 @@ export default {
         задать имя поля как <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="пример массива полей"
         >
           Посмотреть пример с массивом полей

--- a/src/data/V5/zh/api.tsx
+++ b/src/data/V5/zh/api.tsx
@@ -250,7 +250,7 @@ export default {
         <code>name[index]</code>。{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           查看Field Array数组示例

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -537,7 +537,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -288,7 +288,7 @@ export default {
         input name as <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           Check out the Field Array example

--- a/src/data/es/advanced.tsx
+++ b/src/data/es/advanced.tsx
@@ -518,7 +518,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/es/api.tsx
+++ b/src/data/es/api.tsx
@@ -247,7 +247,7 @@ export default {
         un nombre de input como <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="Ejemplo de Field Array"
         >
           Consulta el ejemplo de Field Array

--- a/src/data/jp/advanced.tsx
+++ b/src/data/jp/advanced.tsx
@@ -535,7 +535,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/jp/api.tsx
+++ b/src/data/jp/api.tsx
@@ -246,7 +246,7 @@ export default {
         <code>name[index]</code> のように割り当てることができます。
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           フィールド配列の例をご覧ください

--- a/src/data/kr/advanced.tsx
+++ b/src/data/kr/advanced.tsx
@@ -514,7 +514,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -258,7 +258,7 @@ export default {
         <code>name[index]</code> 형태로 지정할 수 있습니다.
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           여기서 배열 필드 예제를 확인하세요

--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -522,7 +522,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/pt/api.tsx
+++ b/src/data/pt/api.tsx
@@ -245,7 +245,7 @@ export default {
         assinar um campo name com <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           Confira o exemplo com campo Matriz(Array)

--- a/src/data/ru/advanced.tsx
+++ b/src/data/ru/advanced.tsx
@@ -504,7 +504,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/ru/api.tsx
+++ b/src/data/ru/api.tsx
@@ -249,7 +249,7 @@ export default {
         задать имя поля как <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="пример массива полей"
         >
           Посмотреть пример с массивом полей

--- a/src/data/zh/advanced.tsx
+++ b/src/data/zh/advanced.tsx
@@ -467,7 +467,7 @@ export default {
           <a
             target="_blank"
             rel="noopener noreferrer"
-            href="https://github.com/react-hook-form/react-hook-form/blob/master/setup.native.ts"
+            href="https://github.com/react-hook-form/react-hook-form/blob/main/setup.native.ts"
           >
             setup.js
           </a>{" "}

--- a/src/data/zh/api.tsx
+++ b/src/data/zh/api.tsx
@@ -243,7 +243,7 @@ export default {
         <code>name[index]</code>。{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/main/examples/FieldArray.tsx"
           title="example for Field Array"
         >
           查看Field Array数组示例


### PR DESCRIPTION
Hi there,
 
I'm opening this PR as a suggestion, to remove racially-charged and marginalizing terminology; according to the Code Of Conduct:
> In the interest of fostering an open and welcoming environment, we as
contributors and maintainers pledge to making participation in our project and
our community a harassment-free experience for everyone, regardless of age, body
size, disability, ethnicity, sex characteristics, gender identity and expression,
level of experience, education, socio-economic status, nationality, personal
appearance, race, religion, or sexual identity and orientation.

I think it would be great to take a step and take the following three (minor) changes:

1. Replace "master" branch with "main" branch as the default branch. (this PR)
2. Add "other" to gender options (perhaps staying away from gender in the docs is even better) (other PR: https://github.com/react-hook-form/documentation/pull/379)
3. Sort gender options alphabetically (other PR: https://github.com/react-hook-form/documentation/pull/379)

This PR would require that React-Hook-Form also switches from "master" to "main". I've opened a PR for that as well:
https://github.com/react-hook-form/react-hook-form/pull/2268

Related:
https://www.zdnet.com/article/github-to-replace-master-with-alternative-term-to-avoid-slavery-references/