### PR TITLE
fix: default value now is an object property and not a string

### DIFF
--- a/src/components/codeExamples/useFieldArray.ts
+++ b/src/components/codeExamples/useFieldArray.ts
@@ -19,7 +19,7 @@ function App() {
           return (
             <li key={item.id}>
               <input
-                defaultValue={"{item.firstName}"} // make sure to set up defaultValue
+                defaultValue={item.firstName} // make sure to set up defaultValue
                 ref={register()}
               />
 


### PR DESCRIPTION
In the Field Arrays example the _firstname_ is a property of the object _test_, but is being shown as a string _"test.firstname"_. With this pull request both _firstname_ and _lastname_ are being shown properly. 