### PR TITLE
fix typo `render()` -> render={}

### DIFF
--- a/src/data/es/api.tsx
+++ b/src/data/es/api.tsx
@@ -739,17 +739,17 @@ export default {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-                          control={control} 
-                          name="test" 
-                          render(({ onChange, onBlur, value }) => (
-                            <Input 
-                              onTextChange={onChange} 
-                              onTextBlur={onBlur} 
-                              textValue={value} 
-                            />
-                          ))
-                        />
-                        <Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>

--- a/src/data/jp/api.tsx
+++ b/src/data/jp/api.tsx
@@ -750,17 +750,17 @@ export default {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-  control={control} 
-  name="test" 
-  render(({ onChange, onBlur, value }) => (
-    <Input 
-      onTextChange={onChange} 
-      onTextBlur={onBlur} 
-      textValue={value} 
-    />
-  ))
-/>
-<Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>

--- a/src/data/kr/api.tsx
+++ b/src/data/kr/api.tsx
@@ -1025,17 +1025,17 @@ React.useEffect(() => {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-  control={control} 
-  name="test" 
-  render(({ onChange, onBlur, value }) => (
-    <Input 
-      onTextChange={onChange} 
-      onTextBlur={onBlur} 
-      textValue={value} 
-    />
-  ))
-/>
-<Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>

--- a/src/data/pt/api.tsx
+++ b/src/data/pt/api.tsx
@@ -747,17 +747,17 @@ export default {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-  control={control} 
-  name="test" 
-  render(({ onChange, onBlur, value }) => (
-    <Input 
-      onTextChange={onChange} 
-      onTextBlur={onBlur} 
-      textValue={value} 
-    />
-  ))
-/>
-<Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>

--- a/src/data/ru/api.tsx
+++ b/src/data/ru/api.tsx
@@ -1027,17 +1027,17 @@ React.useEffect(() => {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-  control={control} 
-  name="test" 
-  render(({ onChange, onBlur, value }) => (
-    <Input 
-      onTextChange={onChange} 
-      onTextBlur={onBlur} 
-      textValue={value} 
-    />
-  ))
-/>
-<Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>

--- a/src/data/zh/api.tsx
+++ b/src/data/zh/api.tsx
@@ -729,17 +729,17 @@ export default {
               withOutCopy
               url="https://codesandbox.io/s/react-hook-form-v6-controller-24gcl"
               rawData={`<Controller
-  control={control} 
-  name="test" 
-  render(({ onChange, onBlur, value }) => (
-    <Input 
-      onTextChange={onChange} 
-      onTextBlur={onBlur} 
-      textValue={value} 
-    />
-  ))
-/>
-<Controller render={props => <Input {...props} />} />`}
+                  control={control}
+                  name='test'
+                  render={({ onChange, onBlur, value }) => (
+                    <Input
+                      onTextChange={onChange}
+                      onTextBlur={onBlur}
+                      textValue={value}
+                    />
+                  )}
+                />
+                <Controller render={props => <Input {...props} />} />`}
             />
           </td>
         </tr>


### PR DESCRIPTION
Fixed a syntax error in html attribute.