### PR TITLE
Fix code example in Controller docs

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1118,7 +1118,7 @@ React.useEffect(() => {
   render={({ onChange, onBlur, value }) => (
     <Checkbox
       onBlur={onBlur}
-      onChange={e => props.onChange(e.target.checked)}
+      onChange={e => onChange(e.target.checked)}
       checked={value}
     />
   )}


### PR DESCRIPTION
Fixes a typo on the code example. `props` isn't available as everything is destructured.