### PR TITLE
Update `validateCriteriaMode` to `criteriaMode`

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -467,7 +467,7 @@ export default {
         </p>
         <p>
           <b className={typographyStyles.note}>Note:</b> You need to set{" "}
-          <code>validateCriteriaMode</code> to <code>all</code> for this option
+          <code>criteriaMode</code> to <code>'all'</code> for this option
           to work.
         </p>
       </>


### PR DESCRIPTION
The note for `errors { types }` contains the old setting name of `validateCriteriaMode` instead of the new `criteriaMode`.