### PR TITLE
Updated onTouched method

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -106,7 +106,7 @@ export default {
       </>
     ),
     validationOnTouched: (
-      <>Validation will trigger until input is touched (has been focused).</>
+      <>Validation won't trigger until input is touched (has lost focus).</>
     ),
     defaultValues: (goToSection) => (
       <>


### PR DESCRIPTION
It seems the documentation seems to imply Validation will only trigger until an input has been touched "Validation will trigger until input is touched". This should be "won't" trigger until and input is touched.