### PR TITLE
Update Strictly Typed code example with correct implementation of using checkbox with TypeController

### DIFF
--- a/src/components/codeExamples/strictlyTyped.ts
+++ b/src/components/codeExamples/strictlyTyped.ts
@@ -34,7 +34,13 @@ export default function App() {
       <TypedController
         name={['nested', 'array', 0, 'test']}
         defaultValue={false}
-        render={(props) => <Checkbox {...props} />}
+        render={({ onChange, value, ...rest }) => (
+          <Checkbox
+            {...rest}
+            onChange={e => onChange(e.target.checked)}
+            checked={value}
+          />
+        )}
       />
 
       {/* ❌: Type '"notExists"' is not assignable to type 'DeepPath<FormValues, "notExists">'. */}


### PR DESCRIPTION
According to discussion in this issue [Checkbox when using `useTypedController` not working as expected](https://github.com/react-hook-form/react-hook-form/issues/2678#issue-683874150) on the `react-hook-form` repository. This PR updates the code example on how to use Strictly Typed with implementation of checkbox to be more inline with example on how to use Controlled checkbox.