### PR TITLE
Insert &nbsp; at UseFormMethods section for visibility.

### DIFF
--- a/src/data/en/ts.tsx
+++ b/src/data/en/ts.tsx
@@ -40,7 +40,7 @@ export default {
     description: (
       <p>
         This type is useful when you are using <code>Context</code>'s{" "}
-        <code>Consumer</code> instead of
+        <code>Consumer</code> instead of&nbsp;
         <code>useFormContext</code> hook.
       </p>
     ),


### PR DESCRIPTION
The section for `UseFormMethods`,  there is no space  between `of` and `useFormContext`. So, I insert `&nbsp;` explicitly.  https://react-hook-form.com/ts/ 