### PR TITLE
Add id to all "goToSection" tags

### DIFF
--- a/src/components/AdvancedPage.tsx
+++ b/src/components/AdvancedPage.tsx
@@ -125,6 +125,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.AccessibilityA11y = ref)}
+            id="AccessibilityA11y"
           >
             {advanced.accessibility.title}
           </h2>
@@ -136,6 +137,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.WizardFormFunnel = ref)}
+            id="WizardFormFunnel"
           >
             {advanced.wizard.title}
           </h2>
@@ -162,6 +164,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.SmartFormComponent = ref)}
+            id="SmartFormComponent"
           >
             {advanced.smartForm.title}
           </h2>
@@ -173,6 +176,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.FieldArrays = ref)}
+            id="FieldArrays"
           >
             {advanced.fieldArrays.title}
           </h2>
@@ -195,6 +199,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.ErrorMessages = ref)}
+            id="ErrorMessages"
           >
             {advanced.errorMessage.title}
           </h2>
@@ -234,6 +239,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.ConnectForm = ref)}
+            id="ConnectForm"
           >
             {advanced.connectForm.title}
           </h2>
@@ -249,6 +255,7 @@ function Advanced({ defaultLang, advanced }: Props) {
             ref={(ref) =>
               (pageContentRef.current.FormProviderPerformance = ref)
             }
+            id="FormProviderPerformance"
           >
             {advanced.formContext.title}
           </h2>
@@ -267,6 +274,7 @@ function Advanced({ defaultLang, advanced }: Props) {
             ref={(ref) =>
               (pageContentRef.current.ConditionalControlledComponent = ref)
             }
+            id="ConditionalControlledComponent"
           >
             {advanced.conditionalControlledComponent.title}
           </h2>
@@ -292,6 +300,7 @@ function Advanced({ defaultLang, advanced }: Props) {
             ref={(ref) =>
               (pageContentRef.current.ControlledmixedwithUncontrolledComponents = ref)
             }
+            id="ControlledmixedwithUncontrolledComponents"
           >
             {advanced.controlledMixedWithUnControlled.title}
           </h2>
@@ -311,6 +320,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.CustomHookwithResolver = ref)}
+            id="CustomHookwithResolver"
           >
             {advanced.customHookwithResolver.title}
           </h2>
@@ -324,6 +334,7 @@ function Advanced({ defaultLang, advanced }: Props) {
             ref={(ref) =>
               (pageContentRef.current.Workingwithvirtualizedlists = ref)
             }
+            id="Workingwithvirtualizedlists"
           >
             {advanced.workingWithVirtualizedList.title}
           </h2>
@@ -335,6 +346,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.TestingForm = ref)}
+            id="TestingForm"
           >
             {advanced.testingForm.title}
           </h2>
@@ -363,6 +375,7 @@ function Advanced({ defaultLang, advanced }: Props) {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (pageContentRef.current.StrictlyTyped = ref)}
+            id="StrictlyTyped"
           >
             {advanced.strictlyTyped.title}
           </h2>

--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -325,6 +325,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.useFormRef = ref
             }}
+            id="useFormRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -659,6 +660,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.registerRef = ref
             }}
+            id="registerRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -683,6 +685,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.unregisterRef = ref
             }}
+            id="unregisterRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -709,6 +712,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.errorsRef = ref
             }}
+            id="errorsRef"
           >
             <ApiErrors
               currentLanguage={currentLanguage}
@@ -721,6 +725,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.watchRef = ref
             }}
+            id="watchRef"
           >
             <ApiWatch currentLanguage={currentLanguage} api={api} />
           </section>
@@ -729,6 +734,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.handleSubmitRef = ref
             }}
+            id="handleSubmitRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -754,6 +760,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.resetRef = ref
             }}
+            id="resetRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -788,6 +795,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.setErrorRef = ref
             }}
+            id="setErrorRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -833,6 +841,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.clearErrorsRef = ref
             }}
+            id="clearErrorsRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -858,6 +867,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.setValueRef = ref
             }}
+            id="setValueRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -885,6 +895,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.getValuesRef = ref
             }}
+            id="getValuesRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -912,6 +923,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.triggerRef = ref
             }}
+            id="triggerRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -937,6 +949,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.controlRef = ref
             }}
+            id="controlRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -960,6 +973,7 @@ const { register } = useForm<FormInputs>({
             ref={(ref) => {
               apiSectionsRef.current.formStateRef = ref
             }}
+            id="formStateRef"
           >
             <ApiFormState
               currentLanguage={currentLanguage}
@@ -970,7 +984,10 @@ const { register } = useForm<FormInputs>({
 
           <hr />
 
-          <section ref={(ref) => (apiSectionsRef.current.ControllerRef = ref)}>
+          <section
+            ref={(ref) => (apiSectionsRef.current.ControllerRef = ref)}
+            id="ControllerRef"
+          >
             <Controller currentLanguage={currentLanguage} api={api} />
           </section>
 
@@ -978,6 +995,7 @@ const { register } = useForm<FormInputs>({
 
           <section
             ref={(ref) => (apiSectionsRef.current.ErrorMessageRef = ref)}
+            id="ErrorMessageRef"
           >
             <ErrorMessage currentLanguage={currentLanguage} api={api} />
           </section>
@@ -986,13 +1004,17 @@ const { register } = useForm<FormInputs>({
 
           <section
             ref={(ref) => (apiSectionsRef.current.useFormContextRef = ref)}
+            id="useFormContextRef"
           >
             <FormContext currentLanguage={currentLanguage} api={api} />
           </section>
 
           <hr />
 
-          <section ref={(ref) => (apiSectionsRef.current.useWatchRef = ref)}>
+          <section
+            ref={(ref) => (apiSectionsRef.current.useWatchRef = ref)}
+            id="useWatchRef"
+          >
             <UseWatch currentLanguage={currentLanguage} api={api} />
           </section>
 
@@ -1000,6 +1022,7 @@ const { register } = useForm<FormInputs>({
 
           <section
             ref={(ref) => (apiSectionsRef.current.useFieldArrayRef = ref)}
+            id="useFieldArrayRef"
           >
             <UseFieldArray currentLanguage={currentLanguage} api={api} />
           </section>

--- a/src/components/FaqPage.tsx
+++ b/src/components/FaqPage.tsx
@@ -115,6 +115,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question0 = ref)}
+            id="question0"
           >
             {faq.questions[0].title}
           </h2>
@@ -125,6 +126,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question1 = ref)}
+            id="question1"
           >
             {faq.questions[1].title}
           </h2>
@@ -136,6 +138,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question2 = ref)}
+            id="question2"
           >
             {faq.questions[2].title}
           </h2>
@@ -147,6 +150,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question3 = ref)}
+            id="question3"
           >
             {faq.questions[3].title}
           </h2>
@@ -157,6 +161,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question4 = ref)}
+            id="question4"
           >
             {faq.questions[4].title}
           </h2>
@@ -169,6 +174,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question5 = ref)}
+            id="question5"
           >
             {faq.questions[5].title}
           </h2>
@@ -181,6 +187,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question6 = ref)}
+            id="question6"
           >
             {faq.questions[6].title}
           </h2>
@@ -193,6 +200,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question7 = ref)}
+            id="question7"
           >
             {faq.questions[7].title}
           </h2>
@@ -222,6 +230,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question8 = ref)}
+            id="question8"
           >
             {faq.questions[8].title}
           </h2>
@@ -233,6 +242,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question9 = ref)}
+            id="question9"
           >
             {faq.questions[9].title}
           </h2>
@@ -264,6 +274,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question10 = ref)}
+            id="question10"
           >
             {faq.questions[10].title}
           </h2>
@@ -275,6 +286,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question11 = ref)}
+            id="question11"
           >
             {faq.questions[11].title}
           </h2>
@@ -294,6 +306,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question12 = ref)}
+            id="question12"
           >
             {faq.questions[12].title}
           </h2>
@@ -305,6 +318,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question13 = ref)}
+            id="question13"
           >
             {faq.questions[13].title}
           </h2>
@@ -316,6 +330,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question14 = ref)}
+            id="question14"
           >
             {faq.questions[14].title}
           </h2>
@@ -327,6 +342,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question15 = ref)}
+            id="question15"
           >
             {faq.questions[15].title}
           </h2>
@@ -338,6 +354,7 @@ import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'`}
           <h2
             className={typographyStyles.questionTitle}
             ref={(ref) => (sectionsRef.current.question16 = ref)}
+            id="question16"
           >
             {faq.questions[16].title}
           </h2>

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -165,6 +165,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.video.title)
               ] = ref)
             }
+            id={getRefNameFromTitle(getStartedEn.video.title)}
           >
             {getStarted.video.title}
           </h2>
@@ -207,6 +208,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.register.title)
               ] = ref)
             }
+            id={getRefNameFromTitle(getStartedEn.register.title)}
           >
             {getStarted.register.title}
           </h2>
@@ -227,6 +229,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.applyValidation.title)
               ] = ref)
             }
+            id={getRefNameFromTitle(getStartedEn.applyValidation.title)}
           >
             {getStarted.applyValidation.title}
           </h2>
@@ -247,6 +250,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.adapting.title)
               ] = ref)
             }
+            id={getRefNameFromTitle(getStartedEn.adapting.title)}
           >
             {getStarted.adapting.title}
           </h2>
@@ -267,6 +271,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.workWithUI.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.workWithUI.title)}
           >
             {getStarted.workWithUI.title}
           </h2>
@@ -287,6 +292,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.controlledInput.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.controlledInput.title)}
           >
             {getStarted.controlledInput.title}
           </h2>
@@ -307,6 +313,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.globalState.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.globalState.title)}
           >
             {getStarted.globalState.title}
           </h2>
@@ -322,6 +329,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.errors.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.errors.title)}
           >
             {getStarted.errors.title}
           </h2>
@@ -342,6 +350,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.schema.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.schema.title)}
           >
             {getStarted.schema.title}
           </h2>
@@ -379,6 +388,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.reactNative.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.reactNative.title)}
           >
             React Native
           </h2>
@@ -408,6 +418,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
                 getRefNameFromTitle(getStartedEn.typeScript.title)
               ] = ref
             }}
+            id={getRefNameFromTitle(getStartedEn.typeScript.title)}
           >
             TypeScript
           </h2>

--- a/src/components/V5/ApiPageV5.tsx
+++ b/src/components/V5/ApiPageV5.tsx
@@ -326,6 +326,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.useFormRef = ref
             }}
+            id="useFormRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -748,6 +749,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.registerRef = ref
             }}
+            id="registerRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -772,6 +774,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.unregisterRef = ref
             }}
+            id="unregisterRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -798,6 +801,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.errorsRef = ref
             }}
+            id="errorsRef"
           >
             <ApiErrors
               currentLanguage={currentLanguage}
@@ -810,6 +814,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.watchRef = ref
             }}
+            id="watchRef"
           >
             <ApiWatch currentLanguage={currentLanguage} api={api} />
           </section>
@@ -818,6 +823,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.handleSubmitRef = ref
             }}
+            id="handleSubmitRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -840,6 +846,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.resetRef = ref
             }}
+            id="resetRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -882,6 +889,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.setErrorRef = ref
             }}
+            id="setErrorRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -921,6 +929,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.clearErrorRef = ref
             }}
+            id="clearErrorRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -941,6 +950,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.setValueRef = ref
             }}
+            id="setValueRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>setValue: </h2>
@@ -970,6 +980,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.getValuesRef = ref
             }}
+            id="getValuesRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -995,6 +1006,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.triggerValidationRef = ref
             }}
+            id="triggerValidationRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -1018,6 +1030,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.controlRef = ref
             }}
+            id="controlRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -1039,6 +1052,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.formStateRef = ref
             }}
+            id="formStateRef"
           >
             <ApiFormState
               currentLanguage={currentLanguage}
@@ -1049,7 +1063,10 @@ function ApiPage({ formData, defaultLang, api }: Props) {
 
           <hr />
 
-          <section ref={(ref) => (apiSectionsRef.current.ControllerRef = ref)}>
+          <section
+            ref={(ref) => (apiSectionsRef.current.ControllerRef = ref)}
+            id="ControllerRef"
+          >
             <ControllerV5 currentLanguage={currentLanguage} api={api} />
           </section>
 
@@ -1057,6 +1074,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
 
           <section
             ref={(ref) => (apiSectionsRef.current.ErrorMessageRef = ref)}
+            id="ErrorMessageRef"
           >
             <ErrorMessage currentLanguage={currentLanguage} api={api} />
           </section>
@@ -1065,6 +1083,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
 
           <section
             ref={(ref) => (apiSectionsRef.current.useFormContextRef = ref)}
+            id="useFormContextRef"
           >
             <FormContext currentLanguage={currentLanguage} api={api} />
           </section>
@@ -1073,6 +1092,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
 
           <section
             ref={(ref) => (apiSectionsRef.current.useFieldArrayRef = ref)}
+            id="useFieldArrayRef"
           >
             <UseFieldArray currentLanguage={currentLanguage} api={api} />
           </section>
@@ -1081,6 +1101,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
 
           <section
             ref={(ref) => (apiSectionsRef.current.validationResolverRef = ref)}
+            id="validationResolverRef"
           >
             <ValidationResolver currentLanguage={currentLanguage} api={api} />
           </section>
@@ -1091,6 +1112,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.validationSchemaRef = ref
             }}
+            id="validationSchemaRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>
@@ -1116,6 +1138,7 @@ function ApiPage({ formData, defaultLang, api }: Props) {
             ref={(ref) => {
               apiSectionsRef.current.BrowserbuiltinvalidationRef = ref
             }}
+            id="BrowserbuiltinvalidationRef"
           >
             <h2 className={typographyStyles.codeHeading}>
               Browser built-in validation (V3 only)

--- a/src/components/tsPage.tsx
+++ b/src/components/tsPage.tsx
@@ -100,7 +100,10 @@ export default ({ defaultLang }: { defaultLang: string }) => {
         />
 
         <main>
-          <section ref={(ref) => (tsSectionsRef.current.NestedValueRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.NestedValueRef = ref)}
+            id="NestedValueRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].nestedValue.title}</h2>
             </code>
@@ -194,7 +197,10 @@ errors?.key4?.message // no type error`}
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.ResolverRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.ResolverRef = ref)}
+            id="ResolverRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].resolver.title}</h2>
             </code>
@@ -248,6 +254,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.SubmitHandlerRef = ref)}
+            id="SubmitHandlerRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].submitHandler.title}</h2>
@@ -262,7 +269,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.ControlRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.ControlRef = ref)}
+            id="ControlRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].control.title}</h2>
             </code>
@@ -309,6 +319,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.UseFormMethodsRef = ref)}
+            id="UseFormMethodsRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].useFormMethodsRef.title}</h2>
@@ -401,6 +412,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.UseFormOptionsRef = ref)}
+            id="UseFormOptionsRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].useFormOptions.title}</h2>
@@ -429,6 +441,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.UseFieldArrayOptionsRef = ref)}
+            id="UseFieldArrayOptionsRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].useFieldArrayOptions.title}</h2>
@@ -449,7 +462,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.FieldErrorRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.FieldErrorRef = ref)}
+            id="FieldErrorRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].fieldError.title}</h2>
             </code>
@@ -468,7 +484,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.FieldErrorsRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.FieldErrorsRef = ref)}
+            id="FieldErrorsRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].fieldErrors.title}</h2>
             </code>
@@ -484,7 +503,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.FieldRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.FieldRef = ref)}
+            id="FieldRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].field.title}</h2>
             </code>
@@ -502,7 +524,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.FieldValuesRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.FieldValuesRef = ref)}
+            id="FieldValuesRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].fieldValues.title}</h2>
             </code>
@@ -515,7 +540,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.ArrayFieldRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.ArrayFieldRef = ref)}
+            id="ArrayFieldRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].arrayField.title}</h2>
             </code>
@@ -532,7 +560,10 @@ export default function App() {
 
           <hr />
 
-          <section ref={(ref) => (tsSectionsRef.current.ModeRef = ref)}>
+          <section
+            ref={(ref) => (tsSectionsRef.current.ModeRef = ref)}
+            id="ModeRef"
+          >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].mode.title}</h2>
             </code>
@@ -552,6 +583,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.ValidationRulesRef = ref)}
+            id="ValidationRulesRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].validationRules.title}</h2>
@@ -576,6 +608,7 @@ export default function App() {
 
           <section
             ref={(ref) => (tsSectionsRef.current.FormStateProxyRef = ref)}
+            id="FormStateProxyRef"
           >
             <code className={typographyStyles.codeHeading}>
               <h2>{TS[currentLanguage].formStateProxy.title}</h2>


### PR DESCRIPTION
This PR adds id's to as many anchored links as I could find. This will allow docSearch to better map to them, because currently it pastes `#gatsbyfocuswrapper` instead of anything useful. 