### PR TITLE
Rename wizard step2 component

### DIFF
--- a/src/components/codeExamples/formWizard.ts
+++ b/src/components/codeExamples/formWizard.ts
@@ -28,7 +28,7 @@ import { withRouter } from "react-router-dom";
 import { useStateMachine } from "little-state-machine";
 import updateAction from "./updateAction";
 
-const Step2 = props => {
+const Step1 = props => {
   const { register, handleSubmit } = useForm();
   const { action } = useStateMachine(updateAction);
   const onSubmit = data => {
@@ -45,7 +45,7 @@ const Step2 = props => {
   );
 };
 
-export default withRouter(Step2);
+export default withRouter(Step1);
 `
 
 export const step3 = `import React from "react";

--- a/src/components/codeExamples/formWizard.ts
+++ b/src/components/codeExamples/formWizard.ts
@@ -28,7 +28,7 @@ import { withRouter } from "react-router-dom";
 import { useStateMachine } from "little-state-machine";
 import updateAction from "./updateAction";
 
-const Step1 = props => {
+const Step2 = props => {
   const { register, handleSubmit } = useForm();
   const { action } = useStateMachine(updateAction);
   const onSubmit = data => {
@@ -45,7 +45,7 @@ const Step1 = props => {
   );
 };
 
-export default withRouter(Step1);
+export default withRouter(Step2);
 `
 
 export const step3 = `import React from "react";

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -184,7 +184,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -194,7 +194,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -204,7 +204,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/es/advanced.tsx
+++ b/src/data/es/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -206,7 +206,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/jp/advanced.tsx
+++ b/src/data/jp/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -207,7 +207,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/kr/advanced.tsx
+++ b/src/data/kr/advanced.tsx
@@ -182,7 +182,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -192,7 +192,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -201,7 +201,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -206,7 +206,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/ru/advanced.tsx
+++ b/src/data/ru/advanced.tsx
@@ -183,7 +183,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -194,7 +194,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -203,7 +203,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>

--- a/src/data/zh/advanced.tsx
+++ b/src/data/zh/advanced.tsx
@@ -172,7 +172,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -181,7 +181,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>
@@ -190,7 +190,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/form-wizard-pages-kkg7m"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
         />
 
         <p>


### PR DESCRIPTION
In [Wizard (funnel / multi-step) form](https://codesandbox.io/s/react-hook-form-wizard-form-13yud?file=/src/Step2.js) example:
`Step 2` component should be `Step 2`, not `Step 1`.
It may make example reader confused.