### PR TITLE
Nit: Fix stray markdown backticks?

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -126,7 +126,7 @@ export default {
         <p>
           <b className={typographyStyles.note}>Note:</b> It is encouraged that
           you set a <code>defaultValue</code> for all inputs to something
-          non-`undefined` such as the empty string or <code>null</code>.
+          non-<code>undefined</code> such as the empty string or <code>null</code>.
         </p>
         <p>
           You can set an input's default value with{" "}


### PR DESCRIPTION
Not sure on this one, but I'm guessing at some point somebody translated this from markdown, and missed these backticks when they did so.