### PR TITLE
[docs]: remove invalid examples of setValue()

### DIFF
--- a/src/components/V5/codeExamples/setValueTs.tsx
+++ b/src/components/V5/codeExamples/setValueTs.tsx
@@ -22,35 +22,6 @@ export default function App() {
   setValue("number", 1);
   // function setValue<"number", number>(name: "number", value: number, shouldValidate?: boolean | undefined): void
   setValue("number", "error");
-  // ❌: type error
-  setValue([{ string: "test" }]);
-  // function setValue<"string">(namesWithValue: DeepPartial<Pick<FormValues, "string">>[], shouldValidate?: boolean | undefined): void
-  setValue([{ number: "error" }]);
-  // ❌: type error
-  setValue([{
-    string: "test",
-    number: 1
-  }]);
-  // function setValue<"string" | "number">(namesWithValue: DeepPartial<Pick<FormValues, "string" | "number">>[], shouldValidate?: boolean | undefined): void
-  setValue([
-    { string: "test" },
-    { number: 1 },
-  ]);
-  // function setValue<"string" | "number">(namesWithValue: DeepPartial<Pick<FormValues, "string" | "number">>[], shouldValidate?: boolean | undefined): void
-  setValue("object", { number: 1 });
-  // function setValue<"object", { number: number }>(name: "object", value: DeepPartial<{ number: number; boolean: boolean }>, shouldValidate?: boolean | undefined): void
-  setValue("object.boolean", true);
-  // function setValue<"object.boolean", boolean>(name: "object.boolean", value: boolean, shouldValidate?: boolean | undefined): void
-  setValue("array", [{ string: "test" }]);
-  // function setValue<"array", { string: string; }[]>(name: "array", value?: (DeepPartial<{ string: string; boolean: boolean; }> | undefined)[] | undefined, shouldValidate?: boolean | undefined): void
-  setValue("array[1].boolean", true);
-  // function setValue<"array[1].boolean", boolean>(name: "array[1].boolean", value: boolean, shouldValidate?: boolean | undefined): void
-  setValue("array[1].boolean", "noerror");
-  // function setValue<"array[1].boolean", string>(name: "array[1].boolean", value: string, shouldValidate?: boolean | undefined): void
-  setValue<string, boolean>("array[1].boolean", "error");
-  // ❌: type error
-  setValue([{ array: [{ boolean: false }]}]);
-  // function setValue<"array">(namesWithValue: DeepPartial<Pick<FormValues, "array">>[], shouldValidate?: boolean | undefined): void
   
   return <form />;
 }`

--- a/src/components/codeExamples/setValueTypes.ts
+++ b/src/components/codeExamples/setValueTypes.ts
@@ -22,35 +22,6 @@ export default function App() {
   setValue("number", 1);
   // function setValue<"number", number>(name: "number", value: number, shouldValidate?: boolean | undefined): void
   setValue("number", "error");
-  // ❌: type error
-  setValue([{ string: "test" }]);
-  // function setValue<"string">(namesWithValue: DeepPartial<Pick<FormValues, "string">>[], shouldValidate?: boolean | undefined): void
-  setValue([{ number: "error" }]);
-  // ❌: type error
-  setValue([{
-    string: "test",
-    number: 1
-  }]);
-  // function setValue<"string" | "number">(namesWithValue: DeepPartial<Pick<FormValues, "string" | "number">>[], shouldValidate?: boolean | undefined): void
-  setValue([
-    { string: "test" },
-    { number: 1 },
-  ]);
-  // function setValue<"string" | "number">(namesWithValue: DeepPartial<Pick<FormValues, "string" | "number">>[], shouldValidate?: boolean | undefined): void
-  setValue("object", { number: 1 });
-  // function setValue<"object", { number: number }>(name: "object", value: DeepPartial<{ number: number; boolean: boolean }>, shouldValidate?: boolean | undefined): void
-  setValue("object.boolean", true);
-  // function setValue<"object.boolean", boolean>(name: "object.boolean", value: boolean, shouldValidate?: boolean | undefined): void
-  setValue("array", [{ string: "test" }]);
-  // function setValue<"array", { string: string; }[]>(name: "array", value?: (DeepPartial<{ string: string; boolean: boolean; }> | undefined)[] | undefined, shouldValidate?: boolean | undefined): void
-  setValue("array[1].boolean", true);
-  // function setValue<"array[1].boolean", boolean>(name: "array[1].boolean", value: boolean, shouldValidate?: boolean | undefined): void
-  setValue("array[1].boolean", "noerror");
-  // function setValue<"array[1].boolean", string>(name: "array[1].boolean", value: string, shouldValidate?: boolean | undefined): void
-  setValue<string, boolean>("array[1].boolean", "error");
-  // ❌: type error
-  setValue([{ array: [{ boolean: false }]}]);
-  // function setValue<"array">(namesWithValue: DeepPartial<Pick<FormValues, "array">>[], shouldValidate?: boolean | undefined): void
   
   return <form />;
 }`


### PR DESCRIPTION
As identified in a Discord thread, examples of `setValue([{..., ...}])` are no longer valid.