### PR TITLE
Update resolvers examples + add Zod examples

### DIFF
--- a/src/components/FaqPage.tsx
+++ b/src/components/FaqPage.tsx
@@ -211,7 +211,7 @@ const Faq = ({ defaultLang, faq }: Props) => {
             tsRawData={`import { useForm } from 'react-hook-form/dist/index.ie11'; // V6
 import { useForm } from 'react-hook-form/dist/react-hook-form.ie11'; // V5'
 // Resolvers
-import { yupResolver } from '@hookform/resolvers/dist/ie11';`}
+import { yupResolver } from '@hookform/resolvers/dist/ie11/yup';`}
             withOutCopy
           />
           <p>If you encounter: </p>

--- a/src/components/ValidationResolver.tsx
+++ b/src/components/ValidationResolver.tsx
@@ -8,6 +8,8 @@ import validationResolverTs from "./codeExamples/validationResolverTs"
 import TabGroup from "./TabGroup"
 import validationSchema from "./codeExamples/validationSchema"
 import validationSchemaTs from "./codeExamples/validationSchemaTs"
+import zodResolver from "./codeExamples/zodResolver"
+import zodResolverTs from "./codeExamples/zodResolverTs"
 import typographyStyles from "../styles/typography.module.css"
 
 export default function ({ api }) {
@@ -24,12 +26,18 @@ export default function ({ api }) {
 
       {api.resolver.description}
 
-      <TabGroup buttonLabels={["Yup", "Joi", "Superstruct", "Custom"]}>
+      <TabGroup buttonLabels={["Yup", "Zod", "Joi", "Superstruct", "Custom"]}>
         <CodeArea
           rawData={validationSchema}
           tsRawData={validationSchemaTs}
           url="https://codesandbox.io/s/react-hook-form-validationschema-v6-2l77g"
           tsUrl="https://codesandbox.io/s/react-hook-form-validationschema-v6-ts-fpebh"
+        />
+        <CodeArea
+          rawData={zodResolver}
+          tsRawData={zodResolverTs}
+          url="https://codesandbox.io/s/react-hook-form-zod-resolver-example-hsmwu"
+          tsUrl="https://codesandbox.io/s/react-hook-form-zod-resolver-ts-example-x5q37"
         />
         <CodeArea
           rawData={joiResolver}

--- a/src/components/codeExamples/joiResolver.tsx
+++ b/src/components/codeExamples/joiResolver.tsx
@@ -1,6 +1,6 @@
 export default `import React from 'react';
 import { useForm } from 'react-hook-form';
-import { joiResolver } from '@hookform/resolvers';
+import { joiResolver } from '@hookform/resolvers/joi';
 import Joi from "@hapi/joi";
 
 const schema = Joi.object({

--- a/src/components/codeExamples/joiResolverTs.ts
+++ b/src/components/codeExamples/joiResolverTs.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import ReactDOM from "react-dom";
 import { useForm } from "react-hook-form";
-import { joiResolver } from "@hookform/resolvers";
+import { joiResolver } from "@hookform/resolvers/joi";
 import Joi from "@hapi/joi";
 
 interface IFormInput {

--- a/src/components/codeExamples/superStructResolver.tsx
+++ b/src/components/codeExamples/superStructResolver.tsx
@@ -1,6 +1,6 @@
 export default `import React from 'react';
 import { useForm } from 'react-hook-form';
-import { superstructResolver } from '@hookform/resolvers';
+import { superstructResolver } from '@hookform/resolvers/superstruct';
 import { struct } from 'superstruct';
 
 const schema = struct({

--- a/src/components/codeExamples/validationSchema.ts
+++ b/src/components/codeExamples/validationSchema.ts
@@ -1,6 +1,6 @@
 export default `import React from 'react';
 import { useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers';
+import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from "yup";
 
 const schema = yup.object().shape({

--- a/src/components/codeExamples/validationSchemaTs.ts
+++ b/src/components/codeExamples/validationSchemaTs.ts
@@ -1,6 +1,6 @@
 export default `import React from 'react';
 import { useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers';
+import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from "yup";
 
 type Inputs = {

--- a/src/components/codeExamples/zodResolver.ts
+++ b/src/components/codeExamples/zodResolver.ts
@@ -1,0 +1,26 @@
+export default `import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+const schema = z.object({
+  name: z.number(),
+  age: z.number()
+});
+
+const App = () => {
+  const { register, handleSubmit } = useForm({
+    resolver: zodResolver(schema)
+  });
+
+  return (
+    <form onSubmit={handleSubmit((d) => console.log(d))}>
+      <input name="name" ref={register} />
+      <input name="age" type="number" ref={register} />
+      <input type="submit" />
+    </form>
+  );
+};
+
+export default App;
+`

--- a/src/components/codeExamples/zodResolverTs.ts
+++ b/src/components/codeExamples/zodResolverTs.ts
@@ -1,0 +1,28 @@
+export default `import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import * as z from "zod";
+
+const schema = z.object({
+  name: z.number(),
+  age: z.number()
+});
+
+type Schema = z.infer<typeof schema>;
+
+const App = () => {
+  const { register, handleSubmit } = useForm<Schema>({
+    resolver: zodResolver(schema)
+  });
+
+  return (
+    <form onSubmit={handleSubmit((d) => console.log(d))}>
+      <input name="name" ref={register} />
+      <input name="age" type="number" ref={register} />
+      <input type="submit" />
+    </form>
+  );
+};
+
+export default App;
+`

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1455,6 +1455,14 @@ React.useEffect(() => {
           </a>
           ,{" "}
           <a
+            href="https://github.com/vriad/zod"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Zod
+          </a>
+          ,{" "}
+          <a
             href="https://github.com/hapijs/joi"
             target="_blank"
             rel="noopener noreferrer"
@@ -1477,13 +1485,13 @@ React.useEffect(() => {
         <p>
           At this time, we offer{" "}
           <a
-            href="https://github.com/react-hook-form/react-hook-form-resolvers"
+            href="https://github.com/react-hook-form/resolvers"
             target="_blank"
             rel="noopener noreferrer"
           >
             officially supported resolvers
           </a>{" "}
-          for: Yup, Joi and Superstruct.
+          for: Yup, Zod, Joi and Superstruct.
         </p>
 
         <code

--- a/src/data/en/faq.tsx
+++ b/src/data/en/faq.tsx
@@ -336,6 +336,14 @@ export default {
                     </a>
                     ,{" "}
                     <a
+                      href="https://github.com/vriad/zod"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Zod
+                    </a>
+                    ,{" "}
+                    <a
                       href="https://github.com/hapijs/joi"
                       target="_blank"
                       rel="noopener noreferrer"

--- a/src/data/en/getStarted.tsx
+++ b/src/data/en/getStarted.tsx
@@ -269,6 +269,14 @@ export default {
           </a>
           ,{" "}
           <a
+            href="https://github.com/vriad/zod"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Zod
+          </a>{" "}
+          ,{" "}
+          <a
             href="https://github.com/ianstormtaylor/superstruct"
             target="_blank"
             rel="noopener noreferrer"


### PR DESCRIPTION
👋🏻 
Maybe this PR should be merged when resolvers V1 is officially released

I'm not the owner of resolvers examples on codesandbox in order to udpate import, the list of codesandbox to update:
https://codesandbox.io/s/react-hook-form-validationschema-v6-2l77g
https://codesandbox.io/s/react-hook-form-validationschema-v6-ts-fpebh
https://codesandbox.io/s/react-hook-form-joiresolver-v6-yejqe
https://codesandbox.io/s/react-hook-form-joiresolver-v6-ts-jwg5g
https://codesandbox.io/s/react-hook-form-v6-superstructresolver-ed67i