### PR TITLE
Fix centering and padding lang select

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -93,7 +93,6 @@
 
 .langSelect > select {
   width: 100%;
-  line-height: 1.2;
   min-height: 28px;
   font-size: 16px;
   display: block;
@@ -101,9 +100,9 @@
   appearance: none;
   color: white;
   border: 1px solid var(--color-light-blue);
-  text-align: center;
   border-radius: 3px;
   padding-left: 10px;
+  padding-right: 15px;
   cursor: pointer;
   position: relative;
 }


### PR DESCRIPTION
Some small fixes for centering and padding for the language select.
- Vertical align selected language.
- Fix caret icon and longer language names overlap.

Current styling:
![afbeelding](https://user-images.githubusercontent.com/7275740/94864811-d9968000-043c-11eb-9230-d9d96bbeb6b5.png)

Fixed styling:
![afbeelding](https://user-images.githubusercontent.com/7275740/94865036-342fdc00-043d-11eb-9eda-ede413471634.png)

