### PR TITLE
Hide edit button properly

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -50,7 +50,11 @@ const Layout = (props: {
       </a>
       <Nav defaultLang={props.defaultLang} />
       {props.children}
-      <Animate play={show} start={{ opacity: 0 }} end={{ opacity: 1 }}>
+      <Animate
+        play={show}
+        start={{ opacity: 0, visibility: "hidden" }}
+        end={{ opacity: 1, visibility: "visible" }}
+      >
         {editLink && (
           <a
             target="_blank"


### PR DESCRIPTION
If scrolled to the top of a page the edit and scroll buttons are hidden, but if you hover over the hidden element it still changes the cursor and clicking also works. This PR hides the buttons properly.