### PR TITLE
Fixed wording typo in faq

### DIFF
--- a/src/data/en/faq.tsx
+++ b/src/data/en/faq.tsx
@@ -158,7 +158,7 @@ export default {
       ),
     },
     {
-      title: "Why is first keystroke is not working?",
+      title: "Why is the first keystroke not working?",
       description: (
         <>
           <p>


### PR DESCRIPTION
I thought i should remove the repeated `is` and changed the wording a bit. Please lemme know if it was unneeded.