### PR TITLE
fix typescript type in Register fields example

### DIFF
--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -29,7 +29,7 @@ enum GenderEnum {
 }
 
 interface IFormInput {
-  firstName: String;
+  firstName: string;
   gender: GenderEnum;
 }
 


### PR DESCRIPTION
`String` needs to be `string` for the _Register fields_ example to compile