### PR TITLE
Advanced - Accessibility (A11y): add name attribute to fix the forms

### DIFF
--- a/src/components/codeExamples/accessibleCodeBase.ts
+++ b/src/components/codeExamples/accessibleCodeBase.ts
@@ -8,7 +8,7 @@ export default function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor="name">Name</label>
-      <input type="text" id="name" ref={register({ required: true, maxLength: 30 })} />
+      <input type="text" id="name" name="name" ref={register({ required: true, maxLength: 30 })} />
       {errors.name && errors.name.type === "required" && <span>This is required</span>}
       {errors.name && errors.name.type === "maxLength" && <span>Max length exceeded</span> }
       <input type="submit" />

--- a/src/components/codeExamples/accessibleCodeFinal.ts
+++ b/src/components/codeExamples/accessibleCodeFinal.ts
@@ -8,11 +8,12 @@ export default function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor="name">Name</label>
-      
+
       {/* use aria-invalid to indicate field contain error */}
       <input
         type="text"
         id="name"
+        name="name"
         aria-invalid={errors.name ? "true" : "false"}
         ref={register({ required: true, maxLength: 30 })}
       />


### PR DESCRIPTION
Hi !

When working on form validation with [Advanced - Accessibility (A11y)](https://react-hook-form.com/advanced-usage), I realised the forms for accessibility do not work as it misses a name attribut to the input tag. 

See error in console below:
![invalid-form](https://user-images.githubusercontent.com/22852543/98354970-cc634700-2021-11eb-9e61-2f320e491ed4.png)

With my fix, the validation on form works properly:
![valid-form](https://user-images.githubusercontent.com/22852543/98355007-dc7b2680-2021-11eb-940a-f3bdb77b2c76.png)

