### PR TITLE
Fix invalid example defaultValue to name

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1107,7 +1107,7 @@ React.useEffect(() => {
               rawData={`{fields.map((data, index) =>
   <input
     key={data.id}
-    defaultValue={\`data[\${index}].value\`}
+    name={\`data[\${index}].value\`}
   />;
 );}`}
               withOutCopy

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1107,6 +1107,7 @@ React.useEffect(() => {
               rawData={`{fields.map((data, index) =>
   <input
     key={data.id}
+    defaultValue={\`data[\${index}].value\`}
     name={\`data[\${index}].value\`}
   />;
 );}`}


### PR DESCRIPTION
To find this goto, https://react-hook-form.com/api#useFieldArray and the example is just below the text: `Important: Because each input can be uncontrolled, id is required with mapped components to help React to identify which items have changed, are added, or are removed.`