### PR TITLE
Fix typo

### DIFF
--- a/src/components/ApiPage.tsx
+++ b/src/components/ApiPage.tsx
@@ -769,7 +769,7 @@ const { register } = useForm<FormInputs>({
               buttonLabels={[
                 "Uncontrolled",
                 "Controller",
-                "Submit with rest",
+                "Submit with reset",
                 "Field Array",
               ]}
             >


### PR DESCRIPTION
Change a tabname in `reset` api example page from `Submit with rest` => `Submit with reset`