### PR TITLE
Add other necessary IE11 polyfills to the Faq Page

### DIFF
--- a/src/components/FaqPage.tsx
+++ b/src/components/FaqPage.tsx
@@ -244,8 +244,8 @@ import { yupResolver } from '@hookform/resolvers/dist/ie11/yup';`}
           </p>
 
           <p>
-            The following polyfills are necessary, and feel free to let us know
-            or update the doc to reflect other missing polyfills
+            The following polyfills are necessary. Feel free to let us know or
+            update the doc to reflect other missing polyfills.
           </p>
 
           <ul>
@@ -257,6 +257,21 @@ import { yupResolver } from '@hookform/resolvers/dist/ie11/yup';`}
             <li>
               <p>
                 <code>Object.entries</code>
+              </p>
+            </li>
+            <li>
+              <p>
+                <code>Array.find</code>
+              </p>
+            </li>
+            <li>
+              <p>
+                <code>Array.includes</code>
+              </p>
+            </li>
+            <li>
+              <p>
+                <code>String.startsWith</code>
               </p>
             </li>
           </ul>


### PR DESCRIPTION
Polyfills for `String.startsWith`, `Array.find` and `Array.includes` are also required for IE11, but not mentioned in the docs right now.