### PR TITLE
little state machine local storage > session

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,16 +4,11 @@ import formData from "./src/state/formData"
 import language from "./src/state/language"
 import setting from "./src/state/setting"
 
-createStore(
-  {
-    formData,
-    language,
-    setting,
-  },
-  {
-    storageType: window.localStorage,
-  }
-)
+createStore({
+  formData,
+  language,
+  setting,
+})
 
 export const wrapRootElement = ({ element }) => (
   <StateMachineProvider>{element}</StateMachineProvider>

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,11 +4,16 @@ import formData from "./src/state/formData"
 import language from "./src/state/language"
 import setting from "./src/state/setting"
 
-createStore({
-  formData,
-  language,
-  setting,
-})
+createStore(
+  {
+    formData,
+    language,
+    setting,
+  },
+  {
+    storageType: window.localStorage,
+  }
+)
 
 export const wrapRootElement = ({ element }) => (
   <StateMachineProvider>{element}</StateMachineProvider>

--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -165,6 +165,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-required-w69ts?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -203,6 +204,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-maxlength-ctgiu?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -241,6 +243,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-minlength-0v69v?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -266,6 +269,7 @@ export default function ApiRefTable({
                   withOutCopy
                   rawData={`<input
   name="test"
+  type="number"
   ref={
     register({
       max: ${
@@ -279,6 +283,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-max-yg19e?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -304,6 +309,7 @@ export default function ApiRefTable({
                   withOutCopy
                   rawData={`<input
   name="test"
+  type="number"
   ref={
     register({
       min: ${
@@ -317,6 +323,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-min-lxjr7?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -355,6 +362,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-pattern-zgbut?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -434,6 +442,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-valueasnumber-8v2t3?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -462,6 +471,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-valueasdate-700wc?file=/src/App.jsx"
                 />
               </td>
             </tr>
@@ -488,6 +498,7 @@ export default function ApiRefTable({
     })
   }
 />`}
+                  url="https://codesandbox.io/s/react-hook-form-validation-setvalueas-6lirl?file=/src/App.jsx"
                 />
               </td>
             </tr>

--- a/src/state/setting.ts
+++ b/src/state/setting.ts
@@ -1,4 +1,6 @@
 export default {
-  lightMode: null,
+  lightMode: false, // default to dark mode
+  // TODO: inherit mode choice from the user such as below
+  // !window.matchMedia("(prefers-color-scheme: light)").matches
   isFocusOnSearch: false,
 }


### PR DESCRIPTION
This PR:

- adds all but one validation example spoken about in #470. The final example: `validate` I'll finish in the coming week! 
- adds some comments to color defaults and also changes the default from null to false, to make dark-mode default obvious.

