### PR TITLE
add further explanation code about formState props

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -470,6 +470,17 @@ export default {
 `}
         />
 
+        <CodeArea
+          rawData={`// ❌ formState.isValid is accessed conditionally, 
+// so the Proxy does not subscribe to changes of that state
+return <button disabled={!formState.isDirty || !formState.isValid} />;
+  
+// ✅ read all formState values to subscribe to changes
+const { isDirty, isValid } = formState;
+return <button disabled={isDirty || isValid} />;
+`}
+        />
+
         <p>
           <b className={typographyStyles.note}>Important:</b>{" "}
           <code>formState</code> is wrapped with{" "}


### PR DESCRIPTION
Adds a concise code example / do/don't explaining about how to use the `formState` proxy, inspired by [this](https://github.com/react-hook-form/react-hook-form/issues/3673) issue