### PR TITLE
Clarify that valueAsNumber and valueAsDate supersede setValueAs

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -497,6 +497,9 @@ export default function ApiRefTable({
                 <p>
                   <b className={typographyStyles.note}>Note</b>:{" "}
                   <code>valueAs</code> process is happening after validation.
+                  Also, <code>setValueAs</code> is ignored if either{" "}
+                  <code>valueAsNumber</code> or <code>valueAsDate</code> are{" "}
+                  <code>true</code>.
                 </p>
               </td>
               <td>


### PR DESCRIPTION
I was using setValueAs alongside valueAsNumber in my code, and expected the setValueAs function to simply receive a number instead of a string. Instead, the function was ignored.

Looking at https://github.com/react-hook-form/react-hook-form/blob/master/src/logic/getFieldValue.ts#L49, I see this experience is by design:

```ts
return valueAsNumber
    ? +value
    : valueAsDate
    ? (ref as HTMLInputElement).valueAsDate
    : setValueAs
    ? setValueAs(value)
    : value;
```

So I thought it would be helpful to clarify this in the documentation.