### PR TITLE
Fix titles on ts page

### DIFF
--- a/src/components/tsPage.tsx
+++ b/src/components/tsPage.tsx
@@ -516,9 +516,9 @@ export default function App() {
             id="UseControllerMethodsRef"
           >
             <code className={typographyStyles.codeHeading}>
-              <h2>{TS[currentLanguage].useFieldArrayOptions.title}</h2>
+              <h2>{TS[currentLanguage].useControllerMethods.title}</h2>
             </code>
-            {TS[currentLanguage].useFieldArrayOptions.description}
+            {TS[currentLanguage].useControllerMethods.description}
 
             <CodeArea
               rawData={`export type UseControllerMethods<
@@ -538,9 +538,9 @@ export default function App() {
             id="UseControllerOptionsRef"
           >
             <code className={typographyStyles.codeHeading}>
-              <h2>{TS[currentLanguage].useFieldArrayOptions.title}</h2>
+              <h2>{TS[currentLanguage].useControllerOptions.title}</h2>
             </code>
-            {TS[currentLanguage].useFieldArrayOptions.description}
+            {TS[currentLanguage].useControllerOptions.description}
 
             <CodeArea
               rawData={`export type UseControllerOptions<


### PR DESCRIPTION
Hi, thanks for your great library!

I noticed, that the ts page shows the wrong title (and description) for the [UseControllerMethods](https://react-hook-form.com/ts#UseControllerMethods) and [UseControllerOptions](https://react-hook-form.com/ts#UseControllerOptions) sections. Both use the same data as the `UseFieldArrayOptions` section. Probably due to copy and paste.

This PR fixes this.