### PR TITLE
Fix form wizard code sandbox

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,16 +4,11 @@ import formData from "./src/state/formData"
 import language from "./src/state/language"
 import setting from "./src/state/setting"
 
-createStore(
-  {
-    formData,
-    language,
-    setting,
-  },
-  {
-    storageType: window.localStorage,
-  }
-)
+createStore({
+  formData,
+  language,
+  setting,
+})
 
 export const wrapRootElement = ({ element }) => (
   <StateMachineProvider>{element}</StateMachineProvider>

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -4,11 +4,16 @@ import formData from "./src/state/formData"
 import language from "./src/state/language"
 import setting from "./src/state/setting"
 
-createStore({
-  formData,
-  language,
-  setting,
-})
+createStore(
+  {
+    formData,
+    language,
+    setting,
+  },
+  {
+    storageType: window.localStorage,
+  }
+)
 
 export const wrapRootElement = ({ element }) => (
   <StateMachineProvider>{element}</StateMachineProvider>

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -185,7 +185,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -195,7 +195,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -205,7 +205,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/es/advanced.tsx
+++ b/src/data/es/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -206,7 +206,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/jp/advanced.tsx
+++ b/src/data/jp/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -207,7 +207,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/kr/advanced.tsx
+++ b/src/data/kr/advanced.tsx
@@ -182,7 +182,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -192,7 +192,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -201,7 +201,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -187,7 +187,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -197,7 +197,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -206,7 +206,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/ru/advanced.tsx
+++ b/src/data/ru/advanced.tsx
@@ -183,7 +183,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -194,7 +194,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -203,7 +203,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>

--- a/src/data/zh/advanced.tsx
+++ b/src/data/zh/advanced.tsx
@@ -172,7 +172,7 @@ export default {
         </p>
         <CodeArea
           rawData={step1}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -181,7 +181,7 @@ export default {
         </p>
         <CodeArea
           rawData={step2}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>
@@ -190,7 +190,7 @@ export default {
         </p>
         <CodeArea
           rawData={step3}
-          url="https://codesandbox.io/s/react-hook-form-wizard-form-gxvvc"
+          url="https://codesandbox.io/s/react-hook-form-wizard-form-r0zel"
         />
 
         <p>


### PR DESCRIPTION
The bug was brought up here: https://spectrum.chat/react-hook-form/help/official-docs-example-is-not-working-please-check~aa1204e1-d833-4089-b381-c7952d8163d6. I fixed the codesandbox and moved it to our codesandbox "area".