### PR TITLE
useController example fix list of imports

### DIFF
--- a/src/components/codeExamples/useController.ts
+++ b/src/components/codeExamples/useController.ts
@@ -1,6 +1,6 @@
 export default `import React from "react";
 import { TextField } from "@material-ui/core";
-import { useController, control } from "react-hook-form";
+import { useController, useForm } from "react-hook-form";
 
 function Input({ control, name }) {
   const {


### PR DESCRIPTION
Typo: https://react-hook-form.com/api/#useController
![New Project](https://user-images.githubusercontent.com/32715171/107495153-c04ad080-6ba0-11eb-989e-b65707d133e7.png)
