### PR TITLE
Add "Handy form validation in React Native" article to resources

### DIFF
--- a/src/data/resources.tsx
+++ b/src/data/resources.tsx
@@ -4,16 +4,6 @@ export default {
   articles: [
     {
       url:
-        "https://koprowski.it/react-native-form-validation-with-react-hook-form-usecontroller",
-      title:
-        "Handy form validation in React Native with useController hook from react-hook-form ",
-      author: "Daniel Koprowski",
-      authorUrl: "https://twitter.com/Koprowski_it",
-      description:
-        "Managing forms in React Native is different than in React. Custom components need callbacks or wrappers, which can make code hard to read. Here is a handy solution for React Native form validation. Without <Controller /> component!",
-    },
-    {
-      url:
         "https://blog.logrocket.com/react-hook-form-vs-formik-a-technical-and-performance-comparison/",
       title:
         "React Hook Form vs. Formik: A technical and performance comparison",
@@ -308,6 +298,16 @@ export default {
         "React Native Form Management Tutorial - Building a credit card form",
       author: "Halil Bilir",
       authorUrl: "https://twitter.com/hbilirr",
+    },
+    {
+      url:
+        "https://koprowski.it/react-native-form-validation-with-react-hook-form-usecontroller",
+      title:
+        "Handy form validation in React Native with useController hook from react-hook-form ",
+      author: "Daniel Koprowski",
+      authorUrl: "https://twitter.com/Koprowski_it",
+      description:
+        "Managing forms in React Native is different than in React. Custom components need callbacks or wrappers, which can make code hard to read. Here is a handy solution for React Native form validation. Without <Controller /> component!",
     },
   ],
   videos: [

--- a/src/data/resources.tsx
+++ b/src/data/resources.tsx
@@ -4,6 +4,16 @@ export default {
   articles: [
     {
       url:
+        "https://koprowski.it/react-native-form-validation-with-react-hook-form-usecontroller",
+      title:
+        "Handy form validation in React Native with useController hook from react-hook-form ",
+      author: "Daniel Koprowski",
+      authorUrl: "https://twitter.com/Koprowski_it",
+      description:
+        "Managing forms in React Native is different than in React. Custom components need callbacks or wrappers, which can make code hard to read. Here is a handy solution for React Native form validation. Without <Controller /> component!",
+    },
+    {
+      url:
         "https://blog.logrocket.com/react-hook-form-vs-formik-a-technical-and-performance-comparison/",
       title:
         "React Hook Form vs. Formik: A technical and performance comparison",
@@ -294,7 +304,8 @@ export default {
     },
     {
       url: "https://bilir.me/blog/react-native-form-management-tutorial",
-      title: "React Native Form Management Tutorial - Building a credit card form",
+      title:
+        "React Native Form Management Tutorial - Building a credit card form",
       author: "Halil Bilir",
       authorUrl: "https://twitter.com/hbilirr",
     },


### PR DESCRIPTION
I've created an article about react-native-hook usage in React Native.

This implementation uses new `useController` hook which makes codebase much better to understand for developers. This is a new approach as most older tutorials describe the usage of `<Controller />` component.