### PR TITLE
Update to v7 tag documentation for compatibility with devtools

### DIFF
--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -91,7 +91,7 @@ export default ({ defaultLang, content }: Props) => {
             <button
               className={getStartedStyle.copyButton}
               onClick={() => {
-                copyClipBoard("npm install @hookform/devtools -D")
+                copyClipBoard("npm install @hookform/devtools@next -D")
                 alert(generic.copied["en"])
               }}
             >


### PR DESCRIPTION
I ran into an issue using the wrong version with the v7 with v2 of devtools with `typeError: getValues is not a function` via npm tag https://www.npmjs.com/package/@hookform/devtools

![Screen Shot 2021-03-08 at 15 22 13](https://user-images.githubusercontent.com/5950956/110383550-0e2cea00-8022-11eb-8266-555c4e29b2b7.png)
