### PR TITLE
Update to v7 tag documentation for compatibility with devtools

### DIFF
--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -87,7 +87,7 @@ export default ({ defaultLang, content }: Props) => {
               lightMode ? getStartedStyle.lightInstallCode : ""
             }`}
           >
-            npm install @hookform/devtools -D
+            npm install @hookform/devtools@next -D
             <button
               className={getStartedStyle.copyButton}
               onClick={() => {

--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -91,7 +91,7 @@ export default ({ defaultLang, content }: Props) => {
             <button
               className={getStartedStyle.copyButton}
               onClick={() => {
-                copyClipBoard("npm install @hookform/devtools -D")
+                copyClipBoard("npm install @hookform/devtools@next -D")
                 alert(generic.copied["en"])
               }}
             >


### PR DESCRIPTION
I ran into an issue using the wrong version with the v7 with v2 of devtools with `typeError: getValues is not a function` via npm tag https://www.npmjs.com/package/@hookform/devtools

![Screen Shot 2021-03-08 at 15 22 13](https://user-images.githubusercontent.com/5950956/110383550-0e2cea00-8022-11eb-8266-555c4e29b2b7.png)

updated display and copy text 

<img width="1007" alt="Screen Shot 2021-03-08 at 15 32 37" src="https://user-images.githubusercontent.com/5950956/110384651-8f38b100-8023-11eb-825a-0e7de7d9cc79.png">
<img width="1052" alt="Screen Shot 2021-03-08 at 15 32 29" src="https://user-images.githubusercontent.com/5950956/110384653-9069de00-8023-11eb-9c13-b373e16633b9.png">
