### PR TITLE
Remove brackets in default examples to be able to copy/paste it

### DIFF
--- a/src/components/codeExamples/defaultExample.ts
+++ b/src/components/codeExamples/defaultExample.ts
@@ -8,7 +8,7 @@ export default function App() {
   console.log(watch("example")); // watch input value by passing the name of it
 
   return (
-    {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
+    /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
     <form onSubmit={handleSubmit(onSubmit)}>
       {/* register your input into the hook by invoking the "register" function */}
       <input defaultValue="test" {...register("example")} />

--- a/src/components/codeExamples/defaultExampleTs.tsx
+++ b/src/components/codeExamples/defaultExampleTs.tsx
@@ -13,7 +13,7 @@ export default function App() {
   console.log(watch("example")) // watch input value by passing the name of it
 
   return (
-    {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
+    /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
     <form onSubmit={handleSubmit(onSubmit)}>
       {/* register your input into the hook by invoking the "register" function */}
       <input defaultValue="test" {...register("example")} />

--- a/src/components/codeExamples/v6/defaultExample.ts
+++ b/src/components/codeExamples/v6/defaultExample.ts
@@ -8,7 +8,7 @@ export default function App() {
   console.log(watch("example")); // watch input value by passing the name of it
 
   return (
-    {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
+    /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
     <form onSubmit={handleSubmit(onSubmit)}>
       {/* register your input into the hook by invoking the "register" function */}
       <input name="example" defaultValue="test" ref={register} />

--- a/src/components/codeExamples/v6/defaultExampleTs.tsx
+++ b/src/components/codeExamples/v6/defaultExampleTs.tsx
@@ -13,7 +13,7 @@ export default function App() {
   console.log(watch("example")) // watch input value by passing the name of it
 
   return (
-    {/* "handleSubmit" will validate your inputs before invoking "onSubmit" */}
+    /* "handleSubmit" will validate your inputs before invoking "onSubmit" */
     <form onSubmit={handleSubmit(onSubmit)}>
       {/* register your input into the hook by invoking the "register" function */}
       <input name="example" defaultValue="test" ref={register} />


### PR DESCRIPTION
Hello guys,

Just a little PR to be able to copy/paste the example of `Get started` (here https://react-hook-form.com/get-started/) without have to make some changes (remove of brackets).
