### PR TITLE
Patch: Add new error handling on schema validation

### DIFF
--- a/src/components/codeExamples/schemaValidation.ts
+++ b/src/components/codeExamples/schemaValidation.ts
@@ -9,7 +9,7 @@ const schema = yup.object().shape({
 });
 
 export default function App() {
-  const { register, handleSubmit, errors } = useForm({
+  const { register, handleSubmit, formState:{ errors } } = useForm({
     resolver: yupResolver(schema)
   });
   const onSubmit = data => console.log(data);


### PR DESCRIPTION
The code example for the Javascript Schema Validation, had the deprecated way to get the errors from useForm. I just updated it to the V7 way. (Typescript version is ok)