### PR TITLE
Make the gallery card clickable

### DIFF
--- a/src/components/ApiGallery.module.css
+++ b/src/components/ApiGallery.module.css
@@ -50,6 +50,11 @@
   position: absolute;
   right: 0;
   bottom: 0;
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-end;
   padding: 12px 20px 12px 80px;
   font-size: 14px;
 }


### PR DESCRIPTION
I miss click severals times because only the _Read more_ text is clickable. Now the whole gallery card is clickable

![Screenshot 2021-04-03 at 10 26 38](https://user-images.githubusercontent.com/7545547/113473053-73c89680-9467-11eb-9190-0dfa530587d0.png)
