### PR TITLE
fix broken link for v6 fieldArray example.

### DIFF
--- a/src/data/V6/en/api.tsx
+++ b/src/data/V6/en/api.tsx
@@ -331,7 +331,7 @@ export default {
         input name as <code>name[index]</code>.{" "}
         <a
           className={buttonStyles.links}
-          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/FieldArray.tsx"
+          href="https://github.com/react-hook-form/react-hook-form/blob/master/examples/V6/FieldArray.tsx"
           title="example for Field Array"
         >
           Check out the Field Array example


### PR DESCRIPTION
Greetings.
This PR fixes a broken link for fieldArray example in v6 docs.