### PR TITLE
Fix broken ref examples

### DIFF
--- a/src/components/codeExamples/shareRef.ts
+++ b/src/components/codeExamples/shareRef.ts
@@ -5,7 +5,7 @@ export default function App() {
   const { register, handleSubmit } = useForm();
   const firstNameRef = useRef(null);
   const onSubmit = data => console.log(data);
-  const { ref, ...rest } = register('firstName);
+  const { ref, ...rest } = register('firstName');
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/codeExamples/shareRefTs.ts
+++ b/src/components/codeExamples/shareRefTs.ts
@@ -10,7 +10,7 @@ export default function App() {
   const { register, handleSubmit } = useForm<Inputs>();
   const firstNameRef = useRef<HTMLInputElement | null>(null);
   const onSubmit = data => console.log(data);
-  const { ref, ...rest } = register('firstName);
+  const { ref, ...rest } = register('firstName');
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
I stumbled on a small typo on https://react-hook-form.com/faqs#Howtosharerefusage 🙂