### PR TITLE
Fix typos

### DIFF
--- a/src/components/ControllerContent.tsx
+++ b/src/components/ControllerContent.tsx
@@ -30,7 +30,7 @@ export default function ControllerContent({
       <h2 className={typographyStyles.subTitle}>Props</h2>
 
       <p>
-        The following table contains information about all the arguments for{" "}
+        The following table contains information about the arguments for{" "}
         <code>useController</code>.
       </p>
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -61,7 +61,7 @@ export default ({ currentLanguage }: { currentLanguage: string }) => {
         </li>
       </ul>
       <p>
-        Design and Build by{" "}
+        Designed and Built by{" "}
         <a
           href="https://twitter.com/bluebill1049"
           target="_blank"

--- a/src/components/UseControllerContent.tsx
+++ b/src/components/UseControllerContent.tsx
@@ -28,7 +28,7 @@ export default function UseControllerContent({
       {api.useController.description}
       <h2 className={typographyStyles.subTitle}>Props</h2>
       <p>
-        The following table contains information about all the arguments for{" "}
+        The following table contains information about the arguments for{" "}
         <code>useController</code>.
       </p>
       <div className={tableStyles.tableWrapper}>

--- a/src/components/UseControllerMethods.tsx
+++ b/src/components/UseControllerMethods.tsx
@@ -9,7 +9,7 @@ export default ({ currentLanguage, isController }) => {
       <h2 className={typographyStyles.subTitle}>Return</h2>
       <p>
         The following table contains information about properties which{" "}
-        <code>{isController ? "Controller" : "useController"}</code> produce.
+        <code>{isController ? "Controller" : "useController"}</code> produces.
       </p>
       <table className={tableStyles.table}>
         <thead>
@@ -33,8 +33,9 @@ export default ({ currentLanguage, isController }) => {
             </td>
             <td>
               <p>
-                A function which send value to hook form and should be assigned
-                with <code>onChange</code> prop.
+                A function which send the input's value to the library. It
+                should be assigned to the <code>onChange</code> prop of the
+                input.
               </p>
             </td>
           </tr>
@@ -50,8 +51,8 @@ export default ({ currentLanguage, isController }) => {
             </td>
             <td>
               <p>
-                A function which send value to hook form and should be assigned
-                with <code>onBlur</code> prop.
+                A function which sends the input's value to the library. It
+                should be assigned to the input's <code>onBlur</code> prop.
               </p>
             </td>
           </tr>
@@ -64,7 +65,7 @@ export default ({ currentLanguage, isController }) => {
               <code className={typographyStyles.typeText}>unknown</code>
             </td>
             <td>
-              <p>The value of this controlled component.</p>
+              <p>The current value of the controlled component.</p>
             </td>
           </tr>
           <tr>
@@ -77,8 +78,9 @@ export default ({ currentLanguage, isController }) => {
             </tr>
             <td>
               <p>
-                Assign <code>ref</code> to component's input ref, so hook form
-                can focus on the error input.
+                A ref used to connect hook form to the input. Assign{" "}
+                <code>ref</code> to component's input ref to allow hook form to
+                focus the error input.
               </p>
             </td>
           </tr>
@@ -143,7 +145,7 @@ export default ({ currentLanguage, isController }) => {
               <code className={typographyStyles.typeText}>boolean</code>
             </td>
             <td>
-              <p>Indicate the form was successfully submitted.</p>
+              <p>Indicates whether the form was successfully submitted.</p>
             </td>
           </tr>
           <tr>
@@ -188,8 +190,8 @@ export default ({ currentLanguage, isController }) => {
             <td>
               <p>
                 An object with the user-modified fields. Make sure to provide
-                all inputs' defaultValues at the useForm, so hook form can
-                compare with the <code>defaultValue</code>.
+                all inputs' defaultValues via useForm, so the library can
+                compare the input value against the <code>defaultValue</code>.
               </p>
             </td>
           </tr>

--- a/src/components/V5/codeExamples/formState.ts
+++ b/src/components/V5/codeExamples/formState.ts
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 export default function App() {
   const { register, handleSubmit, errors, formState } = useForm();
   const onSubmit = data => console.log(data);
-  // Read the formState before render to subscribe the form state through Proxy
+  // Read the formState before render to subscribe the form state through the Proxy
   const { dirty, isSubmitting, touched, submitCount } = formState;
   
   return (

--- a/src/components/codeExamples/formState.ts
+++ b/src/components/codeExamples/formState.ts
@@ -6,7 +6,7 @@ export default function App() {
     register,
     handleSubmit,
     errors,
-    // Read the formState before render to subscribe the form state through Proxy
+    // Read the formState before render to subscribe the form state through the Proxy
     formState: { isDirty, isSubmitting, touched, submitCount },
   } = useForm();
   const onSubmit = (data: FormInputs) => console.log(data);

--- a/src/components/codeExamples/v6/formStateTs.ts
+++ b/src/components/codeExamples/v6/formStateTs.ts
@@ -10,7 +10,7 @@ export default function App() {
     register,
     handleSubmit,
     errors,
-    // Read the formState before render to subscribe the form state through Proxy
+    // Read the formState before render to subscribe the form state through the Proxy
     formState: { isDirty, isSubmitting, touched, submitCount },
   } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => console.log(data);

--- a/src/data/V6/en/api.tsx
+++ b/src/data/V6/en/api.tsx
@@ -629,7 +629,7 @@ return <button disabled={isDirty || isValid} />;
               <code>watch</code> will return <code>undefined</code> because it
               is called before <code>register</code>, but you can set the{" "}
               <code>defaultValue</code> as the second argument or provide{" "}
-              <code>defaultValues</code> at <code>useForm</code> to avoid this
+              <code>defaultValues</code> via <code>useForm</code> to avoid this
               behaviour.
             </p>
           </li>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -720,7 +720,7 @@ return <button disabled={!isDirty || !isValid} />;
               <code>watch</code> will return <code>undefined</code> because it
               is called before <code>register</code>, but you can set the{" "}
               <code>defaultValue</code> as the second argument or provide{" "}
-              <code>defaultValues</code> at <code>useForm</code> to avoid this
+              <code>defaultValues</code> via <code>useForm</code> to avoid this
               behaviour.
             </p>
           </li>
@@ -733,17 +733,16 @@ return <button disabled={!isDirty || !isValid} />;
           </li>
           <li>
             <p>
-              default value will only get returned in the first invoke before{" "}
-              <code>render</code>, the subsequence invocation will always return
-              what's in the inputs.
+              After the first render, default values will be shallowly merged
+              with the current form values from the inputs.
             </p>
           </li>
           <li>
             <p>
               This API will trigger re-render at the root of your app or form,
-              consider to use callback or{" "}
-              <Link to={"api/usewatch"}>useWatch</Link> api if that's going to
-              be performance issue for you.
+              consider using a callback or the{" "}
+              <Link to={"api/usewatch"}>useWatch</Link> api if you are
+              experiencing performance issues.
             </p>
           </li>
         </ul>
@@ -772,14 +771,14 @@ return <button disabled={!isDirty || !isValid} />;
     description: (
       <>
         <p>
-          This function will pass the form data when form validation is
+          This function will received the form data if form validation is
           successful.
         </p>
 
         <h2 className={typographyStyles.subTitle}>Rules</h2>
         <ul>
           <li>
-            <p>You can easily submit form async with handleSubmit.</p>
+            <p>You can easily submit form asynchronously with handleSubmit.</p>
             <CodeArea
               rawData={`// It can be invoked remotely as well
 handleSubmit(onSubmit)();
@@ -790,10 +789,11 @@ handleSubmit(async (data) => await fetchAPI(data))`}
           </li>
           <li>
             <p>
-              <code>disabled</code> input will be returned{" "}
-              <code>undefined</code> as result, if you want to prevent users
-              from update the input, you can use <code>readOnly</code> or
-              disable the entire {`<fieldset />`}. Here is an{" "}
+              <code>disabled</code> inputs will appear as <code>undefined</code>{" "}
+              values in form values. If you want to prevent users from updating
+              an input and wish to retain the form value, you can use{" "}
+              <code>readOnly</code> or disable the entire {`<fieldset />`}. Here
+              is an{" "}
               <a
                 href="https://codesandbox.io/s/react-hook-form-disabled-inputs-oihxx"
                 target="_blank"
@@ -844,10 +844,7 @@ handleSubmit(async (data) => await fetchAPI(data))`}
     title: "reset",
     description: (
       <>
-        <p>
-          Reset the entire form state, you also have the ability to only reset
-          specific parts of the state.
-        </p>
+        <p>Reset either the entire form state or part of the form state.</p>
 
         <h2 className={typographyStyles.subTitle}>Rules</h2>
 
@@ -857,8 +854,8 @@ handleSubmit(async (data) => await fetchAPI(data))`}
               For controlled components like <code>React-Select</code> which do
               not expose a <code>ref</code> prop, you will have to reset the
               input value manually with{" "}
-              <Link to={"api/useform/api"}>setValue</Link> or hook your
-              component with <Link to={"api/usecontroller"}>useController</Link>{" "}
+              <Link to={"api/useform/api"}>setValue</Link> or connect your
+              component via <Link to={"api/usecontroller"}>useController</Link>{" "}
               or <Link to={"api/usecontroller/controller"}>Controller</Link>.
             </p>
           </li>
@@ -871,20 +868,20 @@ handleSubmit(async (data) => await fetchAPI(data))`}
           </li>
           <li>
             <p>
-              When you are subscribed/read the <code>formState</code>, it's
-              important to decouple <code>reset</code> with{" "}
-              <code>handleSubmit</code>, both are update <code>formState</code>{" "}
-              and <code>handleSubmit</code> is async by default. You can check
-              out a working example below:
+              When you are subscribed to <code>formState</code>, it's important
+              to decouple <code>reset</code> with <code>handleSubmit</code>.
+              Both will update <code>formState</code> and{" "}
+              <code>handleSubmit</code> is async by default. You can check out a
+              working example below:
             </p>
           </li>
           <li>
             <p>
-              When invoking <code>{`reset({ value })`}</code> without supply{" "}
-              <code>defaultValues</code> at <code>useForm</code>, hook form will
-              replace <code>defaultValues</code> with shallow clone{" "}
-              <code>value</code> object which you have supplied{" "}
-              <b>(not deepClone)</b>.
+              When invoking <code>{`reset({ value })`}</code> without supplying{" "}
+              <code>defaultValues</code> via <code>useForm</code>, the library
+              will replace <code>defaultValues</code> with a shallow clone{" "}
+              <code>value</code> object which you provide <b>(not deepClone)</b>
+              .
             </p>
             <CodeArea
               rawData={`// ❌ avoid the following with deep nested default values
@@ -903,8 +900,8 @@ reset({ deepNest: { file: new File() } });
         <h2 className={typographyStyles.subTitle}>Props</h2>
 
         <p>
-          <code>Reset</code> have the ability remain formState update, here are
-          the options in detail:{" "}
+          <code>Reset</code> has the ability to retain formState. Here are the
+          options you may use:{" "}
         </p>
 
         <div className={tableStyles.tableWrapper}>
@@ -977,7 +974,7 @@ reset({ deepNest: { file: new File() } });
                 </td>
                 <td>
                   <p>
-                    Keep the same defaultValues which is initialised at{" "}
+                    Keep the same defaultValues which are initialised via{" "}
                     <code>useForm</code>.
                   </p>
                 </td>
@@ -1017,8 +1014,8 @@ reset({ deepNest: { file: new File() } });
                 </td>
                 <td>
                   <p>
-                    <code>isValid</code> will be temporarily remain as the
-                    current state until further user's action.
+                    <code>isValid</code> will temporarily persist as the current
+                    state until additional user actions.
                   </p>
                 </td>
               </tr>
@@ -1071,7 +1068,7 @@ reset({ deepNest: { file: new File() } });
           </li>
           <li>
             <p>
-              <code>shouldFocusError</code> doesn't work with input been
+              <code>shouldFocusError</code> doesn't work when an input has been
               disabled.
             </p>
           </li>
@@ -1148,8 +1145,8 @@ reset({ deepNest: { file: new File() } });
           </li>
           <li>
             <p>
-              This function will not update formState such as{" "}
-              <code>isValid</code> to true, it only clear errors.
+              This function will not update formState (set <code>isValid</code>{" "}
+              to true). It only clear errors.
             </p>
           </li>
         </ul>
@@ -1232,7 +1229,7 @@ clearErrors('test.firstName'); // for clear single input error
           <strong>
             <code>registered</code>
           </strong>{" "}
-          field. At the same time, it tries to avoid unnecessary re-rerender.
+          field. At the same time, it tries to avoid unnecessary re-rerenders.
         </p>
 
         <h2 className={typographyStyles.subTitle}>Rules</h2>
@@ -1278,8 +1275,8 @@ clearErrors('test.firstName'); // for clear single input error
           </li>
           <li>
             <p>
-              It's recommended to target field name instead using second
-              argument with nested object.
+              It's recommended to target the field's name rather than make the
+              second argument a nested object.
             </p>
 
             <CodeArea
@@ -1290,13 +1287,13 @@ setValue('yourDetails', { firstName: 'value' }); // less performant `}
           </li>
           <li>
             <p>
-              It's recommended to register input name before invoke{" "}
+              It's recommended to register the input's name before invoking{" "}
               <code>setValue</code>. However, the following usages are still
               permitted.
             </p>
             <CodeArea
               rawData={`// you can update an entire Field Array, 
-// this will trigger an entire field array to be remount and refresh with updated values.
+// this will trigger an entire field array to be remount and refreshed with updated values.
 setValue('fieldArray', [{ test: '1' }, { test: '2' }]); // ✅
 
 // you can setValue to a unregistered input
@@ -1338,13 +1335,13 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                 <td>
                   <ul>
                     <li>
-                      <p>Target on a single input by its name.</p>
+                      <p>Target a single input by its name.</p>
                     </li>
                     <li>
                       <p>
-                        Target on field array name, and it will update{" "}
-                        <code>fields</code> object and update entire field
-                        array's internal state.
+                        Target a field array name. Note it will update both the{" "}
+                        <code>fields</code> object and the entire field array's
+                        internal state.
                       </p>
                     </li>
                   </ul>
@@ -1360,8 +1357,8 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                 </td>
                 <td>
                   <p>
-                    value for the field, and make sure supply an entire array
-                    when you update <codep>useFieldArray</codep>.
+                    The value for the field. Make sure you supply the entire
+                    array when you update <codep>useFieldArray</codep>.
                   </p>
                 </td>
               </tr>
@@ -1376,7 +1373,8 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                   <code className={typographyStyles.typeText}>boolean</code>
                 </td>
                 <td>
-                  Should trigger validation during setting the input value.
+                  Whether or not trigger validation while setting the input's
+                  value.
                 </td>
               </tr>
               <tr>
@@ -1389,7 +1387,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                 <td>
                   <code className={typographyStyles.typeText}>boolean</code>
                 </td>
-                <td>Should set the input itself to dirty.</td>
+                <td>Whether to set the input itself to dirty.</td>
               </tr>
             </tbody>
           </table>
@@ -1458,16 +1456,16 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
         <ul>
           <li>
             <p>
-              You shouldn't use this method inside render. This is suitable for
-              reading values in an event handler.
+              Do not use this method inside a render method. It is intended for
+              reading values in an event handler or callback function.
             </p>
           </li>
           <li>
             <p>
-              Disabled input will be returned undefined as result, if you want
-              to prevent users from update the input, you can use{" "}
-              <code>readOnly</code> or disable the entire {`<fieldset />`}. Here
-              is an{" "}
+              Disabled inputs will be returned as <code>undefined</code>. If you
+              want to prevent users from updat the input and still retain the
+              field value, you can use <code>readOnly</code> or disable the
+              entire {`<fieldset />`}. Here is an{" "}
               <a
                 href="https://codesandbox.io/s/react-hook-form-disabled-inputs-oihxx"
                 target="_blank"
@@ -1486,7 +1484,13 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
           </li>
           <li>
             <p>
-              <code>getValues()</code>: Read all form values.
+              After the initial render, form values will be shallowly merged
+              with <code>defaultValues</code>.
+            </p>
+          </li>
+          <li>
+            <p>
+              <code>getValues()</code>: Reads all form values.
             </p>
           </li>
           <li>
@@ -1511,7 +1515,8 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
       <>
         <p>
           Manually triggers form or input validation. This method is also useful
-          when you have depedant validation as react hook form{" "}
+          when you have dependant validation (input validation depends on
+          another input's value).
         </p>
         <h2 className={typographyStyles.subTitle}>Props</h2>
 
@@ -2141,7 +2146,7 @@ React.useEffect(() => {
 
         <p>
           <b className={typographyStyles.note}>Important:</b> do not access any
-          of the property inside this object directly, it's for internal usage
+          of the properties inside this object directly. It's for internal usage
           only.
         </p>
       </>
@@ -2326,8 +2331,8 @@ React.useEffect(() => {
           </td>
           <td></td>
           <td>
-            <code>control</code> object is from invoking <code>useForm</code>.
-            Optional when using <code>FormProvider</code>.
+            <code>control</code> object provided by invoking{" "}
+            <code>useForm</code>. Optional when using <code>FormProvider</code>.
           </td>
         </tr>
         <tr>
@@ -2388,8 +2393,8 @@ React.useEffect(() => {
         <ul>
           <li>
             <p>
-              Do not <code>register</code> input again. This custom hook is made
-              to take care the registration process.
+              Do not <code>register</code> input again. This custom hook is
+              designed to take care of the registration process.
             </p>
             <CodeArea
               rawData={`const { field } = useController({ name: 'test' })
@@ -2401,9 +2406,10 @@ React.useEffect(() => {
           </li>
           <li>
             <p>
-              It's ideal to use single <code>useController</code> per component.
-              If you need to use more than one, make sure you rename the prop or
-              even consider to use <code>Controller</code> instead.
+              It's ideal to use a single <code>useController</code> per
+              component. If you need to use more than one, make sure you rename
+              the prop. May want to consider using <code>Controller</code>{" "}
+              instead.
             </p>
             <CodeArea
               rawData={`const { field: input } = useController({ name: 'test' })
@@ -2420,14 +2426,13 @@ const { field: checkbox } = useController({ name: 'test1' })
     description: (
       <>
         <p>
-          This custom hook is what powers{" "}
+          This custom hook powers{" "}
           <Link to={"/api/usecontroller/controller"}>
             <code>Controller</code>
           </Link>
-          , and shares the same props and methods as <code>Controller</code>.
-          It's useful to create reusable Controlled input, while{" "}
-          <code>Controller</code> is the flexible option to drop into your page
-          or form.
+          . Additionally, it shares the same props and methods as{" "}
+          <code>Controller</code>. It's useful for creating reusable Controlled
+          input.
         </p>
       </>
     ),

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -437,7 +437,7 @@ export default {
           <li>
             <p>
               To produce an array of fields, input names should be followed by a{" "}
-              dot and number. eg: <code>test.0.data</code>
+              dot and number. For example: <code>test.0.data</code>
             </p>
           </li>
           <li>
@@ -2163,7 +2163,7 @@ React.useEffect(() => {
       message: <>Inline error message.</>,
       as: (
         <>
-          Wrapper component or HTML tag. eg: <code>as="span"</code> or{" "}
+          Wrapper component or HTML tag. For example: <code>as="span"</code> or{" "}
           <code>{`as={<Text />}`}</code>
         </>
       ),
@@ -2285,7 +2285,7 @@ React.useEffect(() => {
 
           <li>
             <p>
-              A resolver cannot be used with the built-in validators (eg:{" "}
+              A resolver cannot be used with the built-in validators (e.g.:{" "}
               required, min, etc.)
             </p>
           </li>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -25,9 +25,9 @@ export default {
     ),
     description: (
       <p>
-        <code>useForm</code> is custom hook for managing forms with ease, it
-        also takes <b>optional</b> arguments. The following example demonstrates
-        all of the arguments with their default values.
+        <code>useForm</code> is custom hook for managing forms with ease. It
+        takes <b>optional</b> arguments. The following example demonstrates all
+        of the arguments along with their default values.
       </p>
     ),
     validateCriteriaMode: (
@@ -50,7 +50,7 @@ export default {
       <>
         <p>
           This context <code>object</code> is mutable and will be injected into{" "}
-          <code>resolver</code>'s second argument or{" "}
+          the <code>resolver</code>'s second argument or{" "}
           <a
             href="https://github.com/jquense/yup"
             target="_blank"
@@ -96,7 +96,7 @@ export default {
         <p>
           <b className={typographyStyles.note}>Note:</b> when using with{" "}
           <code>Controller</code>, make sure to wire up <code>onBlur</code> with{" "}
-          <code>render</code> prop.
+          the <code>render</code> prop.
         </p>
       </>
     ),
@@ -107,7 +107,7 @@ export default {
           value when a component is first rendered, before a user interacts with
           it. It is <b>encouraged</b> that you set <code>defaultValues</code>{" "}
           for all inputs to non-
-          <code>undefined</code> such as the empty <code>string</code> or{" "}
+          <code>undefined</code> values such as the empty <code>string</code> or{" "}
           <code>null</code>.
         </p>
         <p>
@@ -119,7 +119,7 @@ export default {
           >
             (read more from the React doc for Default Values)
           </a>
-          , pass <code>defaultValues</code> as an optional argument to{" "}
+          . You can pass <code>defaultValues</code> as an optional argument to{" "}
           <code>useForm()</code> to populate the default values for the entire
           form, or set values on an individual{" "}
           <Link to={"/api/usecontroller/controller"}>Controller</Link> component
@@ -132,8 +132,8 @@ export default {
           <li>
             <p>
               {" "}
-              <code>defaultValues</code> is cached{" "}
-              <strong>at the first render</strong> within the custom hook. If
+              <code>defaultValues</code> are cached{" "}
+              <strong>on the first render</strong> within the custom hook. If
               you want to reset the <code>defaultValues</code>, you should use
               the <Link to={"/api/reset"}>reset</Link> api.
             </p>
@@ -150,22 +150,22 @@ export default {
           </li>
           <li>
             <p>
-              Its not default state for the form, to include additional form
-              values:
+              It's not default for the form, to include additional form values.
+              To do so:
             </p>
             <ol>
               <li>
                 <p>
-                  Register hidden input:{" "}
+                  Register hidden inputs. For example:{" "}
                   <code>{`<input type="hidden" {...register('test'} />`}</code>
                 </p>
               </li>
               <li>
-                <p>Combine values at onSubmit callback.</p>
+                <p>Combine values via the onSubmit callback.</p>
               </li>
               <li>
                 <p>
-                  Register input with value{" "}
+                  Register an input with a value. For example:{" "}
                   <code>{`register('test')({ test: "test"})`}</code>
                 </p>
               </li>
@@ -173,7 +173,7 @@ export default {
           </li>
           <li>
             <p>
-              <code>defaultValues</code> will be shallow merged with form
+              <code>defaultValues</code> will be shallowly merged with form
               submission data.
             </p>
           </li>
@@ -203,8 +203,8 @@ export default {
 
         <p>
           <b className={typographyStyles.note}>Note:</b> only registered fields
-          with <code>ref</code> will work. Custom <code>register</code> inputs
-          do not apply. eg: <code>{`register('test') // doesn't work`}</code>{" "}
+          with a <code>ref</code> will work. Custom registered inputs do not
+          apply. For example: <code>{`register('test') // doesn't work`}</code>{" "}
         </p>
 
         <p>
@@ -247,15 +247,15 @@ export default {
       <>
         <p>
           This method allows you to <code>unregister</code> a single input or an
-          array of inputs. It also provide a second optional argument to keep
-          state after unregister an input.
+          array of inputs. It also provides a second optional argument to keep
+          state after unregistering an input.
         </p>
 
         <div className={tableStyles.tableWrapper}>
           <h2 className={typographyStyles.subTitle}>Props</h2>
 
           <p>
-            Below example shows what to expect when you invoke{" "}
+            The example below shows what to expect when you invoke the{" "}
             <code>unregister</code> method.
           </p>
 
@@ -266,7 +266,7 @@ export default {
           />
 
           <p>
-            Below example shows what to expect when you invoke{" "}
+            The example below shows what to expect when you invoke the{" "}
             <code>unregister</code> method.
           </p>
 
@@ -323,14 +323,15 @@ export default {
     description: (
       <>
         <p>
-          This method allows you to register an input/select and apply
-          validation rules into React Hook Form. Validation rules are all based
-          on HTML standard and also allow custom validation.
+          This method allows you to register an input or select element and
+          apply validation rules to React Hook Form. Validation rules are all
+          based on the HTML standard and also allow for custom validation
+          methods.
         </p>
 
         <p>
-          By invoking the register function and supply input's name, you will
-          receive the following methods:
+          By invoking the register function and supplying an input's name, you
+          will receive the following methods:
         </p>
 
         <div className={tableStyles.tableWrapper}>
@@ -408,19 +409,21 @@ export default {
           <li>
             <p>
               It is <b>required</b> and <b>unique</b> (except native radio and
-              checkbox). Input name also supports dot and bracket syntax, which
+              checkbox). Input name supports both dot and bracket syntax, which
               allows you to easily create nested form fields.
             </p>
           </li>
           <li>
-            <p>It can not start with a number or use number as key name.</p>
+            <p>
+              It can neither start with a number nor use number as key name.
+            </p>
           </li>
           <li>
             <p>
-              <code>disabled</code> input will result as <code>undefined</code>,
-              if you want to prevent users from update the input, you can use{" "}
-              <code>readOnly</code> or disable the entire {`<fieldset />`}. Here
-              is an{" "}
+              <code>disabled</code> input will result in an{" "}
+              <code>undefined</code> form value. If you want to prevent users
+              from updating the input, you can use <code>readOnly</code> or
+              disable the entire {`<fieldset />`}. Here is an{" "}
               <a
                 href="https://codesandbox.io/s/react-hook-form-disabled-inputs-oihxx"
                 target="_blank"
@@ -433,15 +436,15 @@ export default {
           </li>
           <li>
             <p>
-              To produce array fields, input should followed with dot syntax
-              with number. eg: <code>test.0.data</code>
+              To produce an array of fields, input names should be followed by a{" "}
+              dot and number. eg: <code>test.0.data</code>
             </p>
           </li>
           <li>
             <p>
-              Changing name on each render will result <code>register</code> new
-              inputs. It's recommend to keep static name for each registered
-              input.
+              Changing the name on each render will result in new inputs being
+              being registered. It's recommend to keep static names for each
+              registered input.
             </p>
           </li>
         </ul>
@@ -462,9 +465,9 @@ export default {
           <h4 className={typographyStyles.questionTitle}>Custom Register</h4>
 
           <p>
-            You can also <code>register</code> inputs at <code>useEffect</code>{" "}
-            and treat them as virtual inputs. For controlled components, we
-            provide a custom hook{" "}
+            You can also <code>register</code> inputs with{" "}
+            <code>useEffect</code> and treat them as virtual inputs. For
+            controlled components, we provide a custom hook{" "}
             <Link to={"/api/usecontroller"}>useController</Link> and{" "}
             <Link to={"/api/usecontroller/controller"}>Controller</Link>{" "}
             component to take care this process for you.
@@ -478,7 +481,7 @@ export default {
           <CodeArea
             rawData={`register('firstName', { required: true, min: 8 });
             
-const { onChange } = register('lastChange'); // this onChange method can update input value
+const { onChange } = register('lastChange'); // this onChange method can update the input value
 
 // This will work for React Native, except you can't reset input value
 <TextInput onTextChange={onChange} />`}
@@ -515,11 +518,11 @@ const { onChange } = register('lastChange'); // this onChange method can update 
             (refer to the examples)
           </p>
           <p>
-            <b className={typographyStyles.note}>Note:</b> <code>object</code>{" "}
-            or <code>array</code> input data, it's recommend to use{" "}
-            <code>validate</code> function to validate as the other rules are
-            mostly apply to <code>string</code>, <code>number</code> and{" "}
-            <code>boolean</code> data type.
+            <b className={typographyStyles.note}>Note:</b> for{" "}
+            <code>object</code> or <code>array</code> input data, it's recommend
+            to use the <code>validate</code> function for validation as the
+            other rules mostly apply to <code>string</code>, <code>number</code>{" "}
+            and <code>boolean</code> data type.
           </p>
         </>
       ),
@@ -531,15 +534,15 @@ const { onChange } = register('lastChange'); // this onChange method can update 
       <>
         <p>
           This object contains information about the form state. If you want to
-          subscribe to <code>formState</code> update at <code>useEffect</code>,
-          make sure that you place the entire <code>formState</code> in the
-          optional array.
+          subscribe to <code>formState</code> via <code>useEffect</code>, make
+          sure that you place the entire <code>formState</code> in the optional
+          array.
         </p>
 
         <h2 className={typographyStyles.subTitle}>Rules</h2>
 
         <p>
-          <code>formState</code> is wrapped with{" "}
+          <code>formState</code> is wrapped with a{" "}
           <a
             href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy"
             target="_blank"
@@ -548,10 +551,10 @@ const { onChange } = register('lastChange'); // this onChange method can update 
             Proxy
           </a>{" "}
           to improve render performance and skip extra logic if specific state
-          is not subscribed, so make sure you invoke or read it before{" "}
-          <code>render</code> in order to enable the state update. This reduced
-          re-render feature only applies to the Web platform due to a lack of
-          support for Proxy in React Native.
+          is not subscribed to. Therefore make sure you invoke or read it before{" "}
+          a <code>render</code> in order to enable the state update. This
+          reduced re-render feature only applies to the Web platform due to a
+          lack of support for Proxy in React Native.
         </p>
 
         <TabGroup buttonLabels={["snippet", "example"]}>
@@ -596,8 +599,8 @@ return <button disabled={!isDirty || !isValid} />;
           </li>
           <li>
             <p>
-              File typed input will need to manage at app level due to the
-              ability to cancel file selection and{" "}
+              File typed input will need to be managed at the app level due to
+              the ability to cancel file selection and{" "}
               <a
                 href="https://developer.mozilla.org/en-US/docs/Web/API/FileList"
                 target="_blank"
@@ -626,8 +629,8 @@ return <button disabled={!isDirty || !isValid} />;
       <>
         <p>
           An object with the user-modified fields. Make sure to provide all
-          inputs' defaultValues at the useForm, so hook form can compare with
-          the <code>defaultValue</code>.
+          inputs' defaultValues via useForm, so the library can compare against
+          the <code>defaultValues</code>.
         </p>
       </>
     ),
@@ -1412,7 +1415,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
           />
 
           <p>
-            Below example shows what to expect when you invoke{" "}
+            The example below shows what to expect when you invoke{" "}
             <code>getValues</code> method.
           </p>
 
@@ -2251,8 +2254,9 @@ React.useEffect(() => {
         <ul>
           <li>
             <p>
-              Make sure you are returning an object that has <code>values</code>{" "}
-              and <code>errors</code> properties. Their default values should be{" "}
+              Make sure you are returning an object that has both a{" "}
+              <code>values</code> and an <code>errors</code> property. Their
+              default values should be an empty object. For example:{" "}
               <code>{`{}`}</code>.
             </p>
           </li>
@@ -2260,15 +2264,14 @@ React.useEffect(() => {
           <li>
             <p>
               The keys of the <code>error</code> object should match the{" "}
-              <code>name</code> value of your fields.
+              <code>name</code> values of your fields.
             </p>
           </li>
 
           <li>
             <p>
               This function will be cached, while <code>context</code> is a
-              mutable <code>object</code> which can be changed on each
-              re-render.
+              mutable <code>object</code> that can be changed on each re-render.
             </p>
           </li>
 
@@ -2276,15 +2279,14 @@ React.useEffect(() => {
             <p>
               Re-validation of an input will only occur one field at time during
               a user’s interaction. The lib itself will evaluate the{" "}
-              <code>error</code>
-              object to trigger a re-render accordingly.
+              <code>error</code> object to trigger a re-render accordingly.
             </p>
           </li>
 
           <li>
             <p>
-              Resolver can not be used with built-in (eg: required, min and etc)
-              validator, and stick with either usage.
+              A resolver cannot be used with the built-in validators (eg:{" "}
+              required, min, etc.)
             </p>
           </li>
         </ul>

--- a/src/data/generic.tsx
+++ b/src/data/generic.tsx
@@ -339,7 +339,7 @@ export default {
   control: {
     en: (
       <>
-        <code>control</code> object is from invoking <code>useForm</code>. it's
+        <code>control</code> object provided by <code>useForm</code>. It's
         optional if you are using FormContext.
       </>
     ),


### PR DESCRIPTION
This PR fixes additional typos and improves the grammar for the English version of the docs. Note I have updated both `watch` and `getValues` documentation to state that default values are shallowly merged with form values on **each** call. The docs stated this was only true for the first render which is incorrect based on how the library currently works and the RFC. Please let me know if any of my changes result in incorrect documentation. 