### PR TITLE
Fix small typo in UseControllerMethods doc

### DIFF
--- a/src/components/UseControllerMethods.tsx
+++ b/src/components/UseControllerMethods.tsx
@@ -33,7 +33,7 @@ export default ({ currentLanguage, isController }) => {
             </td>
             <td>
               <p>
-                A function which send the input's value to the library. It
+                A function which sends the input's value to the library. It
                 should be assigned to the <code>onChange</code> prop of the
                 input.
               </p>


### PR DESCRIPTION
This fixes a small typo I found while reading the docs.

Thanks for all the work on this library and it's docs!