### PR TITLE
Fixed wrong word in typescript data from `Sidemenu`

### DIFF
--- a/src/components/tsPage.tsx
+++ b/src/components/tsPage.tsx
@@ -20,7 +20,7 @@ const enLinks = [
   TS.fieldErrors,
   TS.field,
   TS.fieldValues,
-  TS.arrayField,
+  TS.fieldArray,
   TS.mode,
   TS.validationRules,
   TS.formStateProxy,
@@ -46,7 +46,7 @@ export default ({ defaultLang }: { defaultLang: string }) => {
     FieldErrorsRef: null,
     FieldRef: null,
     FieldValuesRef: null,
-    ArrayFieldRef: null,
+    FieldArrayRef: null,
     ModeRef: null,
     FormStateProxyRef: null,
   })
@@ -274,13 +274,13 @@ export default ({ defaultLang }: { defaultLang: string }) => {
           <hr />
 
           <section
-            ref={(ref) => (tsSectionsRef.current.ArrayFieldRef = ref)}
-            id="ArrayFieldRef"
+            ref={(ref) => (tsSectionsRef.current.FieldArrayRef = ref)}
+            id="FieldArrayRef"
           >
             <code className={typographyStyles.codeHeading}>
-              <h2>{TS.arrayField.title}</h2>
+              <h2>{TS.fieldArray.title}</h2>
             </code>
-            {TS.arrayField.description}
+            {TS.fieldArray.description}
           </section>
 
           <hr />

--- a/src/data/ts.tsx
+++ b/src/data/ts.tsx
@@ -189,7 +189,7 @@ export default function App() {
     ),
   },
   useFormMethodsRef: {
-    title: "UseFormReturn",
+    title: "UseFormMethods",
     description: (
       <CodeArea
         url={
@@ -276,7 +276,7 @@ export default function App() {
     ),
   },
   useFormOptions: {
-    title: "UseFormProps",
+    title: "UseFormOptions",
     description: (
       <CodeArea
         rawData={`export type UseFormOptions<
@@ -297,7 +297,7 @@ export default function App() {
     ),
   },
   useFieldArrayOptions: {
-    title: "UseFieldArrayProps",
+    title: "UseFieldArrayOptions",
     description: (
       <CodeArea
         rawData={`export type UseFieldArrayOptions<
@@ -312,7 +312,7 @@ export default function App() {
     ),
   },
   useFieldArrayMethods: {
-    title: "UseFieldArrayReturn",
+    title: "UseFieldArrayMethods",
     description: (
       <CodeArea
         rawData={`export type UseFieldArrayMethods<
@@ -399,7 +399,7 @@ export default function App() {
     ),
   },
   validationRules: {
-    title: "RegisterProps",
+    title: "RegisterOptions",
     description: (
       <CodeArea
         rawData={`export type RegisterOptions = Partial<{
@@ -415,7 +415,7 @@ export default function App() {
       />
     ),
   },
-  arrayField: {
+  fieldArray: {
     title: "FieldArray",
     description: (
       <CodeArea
@@ -446,7 +446,7 @@ export default function App() {
     ),
   },
   useControllerOptions: {
-    title: "UseControllerProps",
+    title: "UseControllerOptions",
     description: (
       <CodeArea
         rawData={`export type UseControllerOptions<
@@ -463,7 +463,7 @@ export default function App() {
     ),
   },
   useControllerMethods: {
-    title: "UseControllerReturn",
+    title: "UseControllerMethods",
     description: (
       <CodeArea
         rawData={`export type UseControllerMethods<


### PR DESCRIPTION
try yourself https://react-hook-form.com/ts and tap `UseFormReturn`  is not working that's why I decided to fix it to avoid error

I simply changed different string and only one variable

So I managed to fix it if there is any mistake please let me know 