### PR TITLE
document missing act() warning behavior

### DIFF
--- a/src/components/codeExamples/testingForm.ts
+++ b/src/components/codeExamples/testingForm.ts
@@ -133,37 +133,25 @@ describe("App", () => {
 });
 `
 
-export const actWarningComponent = `import React, { useState } from "react";
+export const actWarningComponent = `import React from "react";
 import { useForm } from "react-hook-form";
 
 export default function App() {
   const { register, handleSubmit, formState } = useForm({
     mode: "onChange"
   });
-  const [message, setMessage] = useState("");
-
-  const onSubmit = (data) => 
-    setMessage(data.answer === "42" ? "that's correct" : "that's incorrect");
+  const onSubmit = (data) => {};
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <section>
-        <label htmlFor="answer">
-          The Answer to the Ultimate Question of Life, The Universe, and
-          Everything
-        </label>
-        <input
-          id="answer"
-          {...register("answer", {
-            required: true
-          })}
-          type="text"
-        />
-      </section>
-      <button type="submit" disabled={!formState.isValid}>
+      <input
+        {...register("answer", {
+          required: true
+        })}
+      />
+      <button type="submit">
         SUBMIT
       </button>
-      <span>{message}</span>
     </form>
   );
 }
@@ -190,7 +178,6 @@ import App from "./App";
 describe("App", () => {
   it("should have a submit button", async () => {
     await act(async () => render(<App />));
-
     expect(screen.getByText("SUBMIT")).toBeInTheDocument();
   });
 });

--- a/src/components/codeExamples/testingForm.ts
+++ b/src/components/codeExamples/testingForm.ts
@@ -132,3 +132,67 @@ describe("App", () => {
   });
 });
 `
+
+export const actWarningComponent = `import React, { useState } from "react";
+import { useForm } from "react-hook-form";
+
+export default function App() {
+  const { register, handleSubmit, formState } = useForm({
+    mode: "onChange"
+  });
+  const [message, setMessage] = useState("");
+
+  const onSubmit = (data) => 
+    setMessage(data.answer === "42" ? "that's correct" : "that's incorrect");
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <section>
+        <label htmlFor="answer">
+          The Answer to the Ultimate Question of Life, The Universe, and
+          Everything
+        </label>
+        <input
+          id="answer"
+          {...register("answer", {
+            required: true
+          })}
+          type="text"
+        />
+      </section>
+      <button type="submit" disabled={!formState.isValid}>
+        SUBMIT
+      </button>
+      <span>{message}</span>
+    </form>
+  );
+}
+
+`
+export const actWarningTest = `
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import App from "./App";
+
+describe("App", () => {
+  it("should have a submit button", () => {
+    render(<App />);
+    expect(screen.getByText("SUBMIT")).toBeInTheDocument();
+  });
+});
+`
+
+export const actWarningSolution = `
+import React from "react";
+import { render, screen, act } from "@testing-library/react";
+import App from "./App";
+
+describe("App", () => {
+  it("should have a submit button", async () => {
+    await act(async () => render(<App />));
+
+    expect(screen.getByText("SUBMIT")).toBeInTheDocument();
+  });
+});
+
+`

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -510,25 +510,20 @@ export default {
           url="https://codesandbox.io/s/react-hook-form-unit-test-docs-066zk?file=/src/App.test.js"
         />
 
-        <p>
-          <span className={typographyStyles.note}>
-            Resolving{" "}
-            <span className={typographyStyles.typeText}>
-              Warning: An update to MyComponent inside a test was not wrapped in
-              act(...)
-            </span>
-          </span>
-        </p>
+        <h4>
+          Resolving act warning during test
+        </h4>
 
         <p>
           If you test a component that uses react-hook-form you might run into a
           warning like this, even if you didn't write any asynchronous code for
           that component:
-          <blockquote>
-            Warning: An update to MyComponent inside a test was not wrapped in
-            act(...)
-          </blockquote>
         </p>
+        
+        <blockquote>
+          Warning: An update to MyComponent inside a test was not wrapped in
+          act(...)
+        </blockquote>
 
         <CodeArea
           rawData={CodeExampleTestingForm.actWarningComponent}

--- a/src/data/en/advanced.tsx
+++ b/src/data/en/advanced.tsx
@@ -509,6 +509,60 @@ export default {
           rawData={CodeExampleTestingForm.step3}
           url="https://codesandbox.io/s/react-hook-form-unit-test-docs-066zk?file=/src/App.test.js"
         />
+
+        <p>
+          <span className={typographyStyles.note}>
+            Resolving{" "}
+            <span className={typographyStyles.typeText}>
+              Warning: An update to MyComponent inside a test was not wrapped in
+              act(...)
+            </span>
+          </span>
+        </p>
+
+        <p>
+          If you test a component that uses react-hook-form you might run into a
+          warning like this, even if you didn't write any asynchronous code for
+          that component:
+          <blockquote>
+            Warning: An update to MyComponent inside a test was not wrapped in
+            act(...)
+          </blockquote>
+        </p>
+
+        <CodeArea
+          rawData={CodeExampleTestingForm.actWarningComponent}
+          url="https://codesandbox.io/s/react-hook-form-unit-test-act-warning-docs-yq7uj?file=/src/App.js"
+        />
+
+        <CodeArea
+          rawData={CodeExampleTestingForm.actWarningTest}
+          url="https://codesandbox.io/s/react-hook-form-unit-test-act-warning-docs-yq7uj?file=/src/App.test.js"
+        />
+
+        <p>
+          In this example, there is a simple form without any apparent async
+          code and the test merely renders the component and tests for the
+          presence of a button. However, it still logs the warning about updates
+          not being wrapped in <code>act()</code>.
+        </p>
+
+        <p>
+          This is because react-hook-form internally uses asynchronous
+          validation handlers. In order to compute the formState it has to
+          initially validate the form, which is done asynchronously, resulting
+          in another render. That update happens after the test function returns
+          which triggers the warning.
+        </p>
+
+        <p>
+          To solve this, wrap your <code>render()</code> calls in{" "}
+          <code>await act(async () ={`> {}`})</code>:
+        </p>
+        <CodeArea
+          rawData={CodeExampleTestingForm.actWarningSolution}
+          url="https://codesandbox.io/s/react-hook-form-unit-test-act-warning-docs-yq7uj?file=/src/App.test.js"
+        />
       </>
     ),
   },


### PR DESCRIPTION
Explaining a (what I found to be a) confusing issue regarding logged warnings about missing `act(...)` calls in unit tests with react-testing-library. 

It's what I took away from these issues: 
https://github.com/react-hook-form/react-hook-form/issues/532
https://github.com/react-hook-form/react-hook-form/issues/4231

Let me know if my interpretation was not correct or you think it should rather be placed into the FAQ section.