### PR TITLE
Fix email regex pattern

### DIFF
--- a/src/components/codeExamples/testingForm.ts
+++ b/src/components/codeExamples/testingForm.ts
@@ -21,7 +21,7 @@ export default function App({ login }) {
         {...register("email", {
           required: "required",
           pattern: {
-            value: /\\S+@\\S+\.\\S+/,
+            value: /\\S+@\\S+\\.\\S+/,
             message: "Entered value does not match email format"
           }
         })}


### PR DESCRIPTION
```ts
pattern: {
  value: /\S+@\S+.\S+/,
  message: "Entered value does not match email format"
}
```

Should be

```ts
pattern: {
  value: /\S+@\S+\.\S+/,
  message: "Entered value does not match email format"
}
```