### PR TITLE
docs: update `getValues` documentation

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1503,7 +1503,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                   <code>getValues("yourDetails.firstName")</code>
                 </td>
                 <td>
-                  <code>{`{ lastName: '' }`}</code>
+                  <code>{`{ firstName: '' }`}</code>
                 </td>
               </tr>
               <tr>
@@ -1511,7 +1511,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
                   <code>getValues(["yourDetails.lastName"])</code>
                 </td>
                 <td>
-                  <code>{`[{ firstName: '' }]`}</code>
+                  <code>{`[{ lastName: '' }]`}</code>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Thanks for the awesome documentation! I can't ask for more, it has proper explanation for every field, good description, CodeSandbox examples, even TypeScript. However, there was one thing that made me confused. 

## Before

This part below, the docs (https://react-hook-form.com/api/useform/getvalues) says when we supply the `firstName`, it returns `lastName` and vice versa. I think it should be consistent with the argument that we pass to the function, as reflected by the Sandbox in the same section.

![image](https://user-images.githubusercontent.com/7077157/118344655-88657780-b559-11eb-8203-e088e2474bc4.png)

## Checklists

- [x] I have tested the documentation using `yarn start`
- [x] I have run `yarn format`

## After

This PR swaps the `.firstName` and `.lastName` in the documentation. I have cross-checked this with the sandbox in https://codesandbox.io/s/react-hook-form-v7-getvalues-2eioh and it worked as expected—`getValues(field)` will return `{ [field]: fieldValue }`.

![image](https://user-images.githubusercontent.com/7077157/118344701-e5f9c400-b559-11eb-806d-42a4c3ec70ef.png)