### PR TITLE
docs: add small note about `submitFocusError`

### DIFF
--- a/src/data/V6/en/api.tsx
+++ b/src/data/V6/en/api.tsx
@@ -247,7 +247,9 @@ export default {
         <p>
           <b className={typographyStyles.note}>Note:</b> only registered fields
           with <code>ref</code> will work. Custom <code>register</code> inputs
-          do not apply. eg: <code>{`register('test') // doesn't work`}</code>{" "}
+          do not apply. eg: <code>{`register('test') // doesn't work`}</code>{" "}<br/>
+          However you're still able to use `forwardRef` to forward the ref and let
+          the autofocus do its work.
         </p>
 
         <p>


### PR DESCRIPTION
I noticed that the autofocus on error doesn't work when using "custom" components like mentioned in the documentation (`submitFocusError`). However, forwarding the ref makes this work. I thought it was worth mentioning

```jsx
const Input = React.forwardRef((props, ref) => {
  return <input {...props} ref={ref}></input>;
});
```