### PR TITLE
Note valueAs breaking changes in migration guide

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -2229,8 +2229,8 @@ React.useEffect(() => {
             </>
             <p>
               <b className={typographyStyles.note}>Important:</b> doesn't
-              support
-              <code>valueAs</code> for <code>useController</code>.
+              support <code>setValueAs</code> or <code>valueAs*</code> for{" "}
+              <code>useController</code>.
             </p>
             <CodeArea
               url="https://codesandbox.io/s/controller-rules-ipynf"

--- a/src/pages/migrate-v6-to-v7.en.tsx
+++ b/src/pages/migrate-v6-to-v7.en.tsx
@@ -228,6 +228,14 @@ npm i @hookform/devtools@latest  // @hookform/devtools: "^3.0.0" if you are usin
 - <Controller render={(props, meta) => <input {...props} />} />
 + <Controller render={({ field, fieldState }) => <input {...field} />} />`}
               />
+
+              <h3>ValueAs</h3>
+              <p>
+                The Controller component <code>rules</code> prop no longer
+                supports <code>setValueAs</code> or <code>valueAs*</code> for{" "}
+                <code>useController</code>. Do these value transformations in
+                your controlled component.
+              </p>
             </section>
 
             <hr />


### PR DESCRIPTION
👋 Hello and thanks for react-hook-form!

I'm knee deep in a migration from v6 to v7 and have been caught by https://github.com/react-hook-form/react-hook-form/issues/4673 which wasn't mentioned in the migration guide, so I added it here in case it helps anyone in the future.

There are a bunch of other breaking changes I've noticed in the typings (e.g. FieldArray* -> ArrayField*), but I've been kicking that can down the road for now 😄