### PR TITLE
fix a typo in the API documentation

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -159,7 +159,7 @@ export default {
               <li>
                 <p>
                   Register hidden inputs. For example:{" "}
-                  <code>{`<input type="hidden" {...register('test'} />`}</code>
+                  <code>{`<input type="hidden" {...register('test')} />`}</code>
                 </p>
               </li>
               <li>


### PR DESCRIPTION
add a missing closing round bracket