### PR TITLE
Typo on (/api/useform/getvalues) getValues api documentation.

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1643,7 +1643,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅
           <li>
             <p>
               Disabled inputs will be returned as <code>undefined</code>. If you
-              want to prevent users from updat the input and still retain the
+              want to prevent users from updating the input and still retain the
               field value, you can use <code>readOnly</code> or disable the
               entire {`<fieldset />`}. Here is an{" "}
               <a


### PR DESCRIPTION
Hello @bluebill1049, I started using react-hook-form for my side project and I am loving it.

There's a typo in the getValues api documentation.
In the docs [api/useForm/getValues](https://react-hook-form.com/api/useform/getvalues)

Check the second point under rules:

> Disabled inputs will be returned as undefined. If you want to prevent users from  _**updat**_ the input and still retain the field value, you can use readOnly or disable the entire `<fieldset />`.

I changed the word _**updat**_ to _**updating**_ according to the sentence.

Hope this is valid change.

Regards,
Rohit