### PR TITLE
Fix incorrect variable names

### DIFF
--- a/src/components/codeExamples/formState.ts
+++ b/src/components/codeExamples/formState.ts
@@ -6,7 +6,7 @@ export default function App() {
     register,
     handleSubmit,
     // Read the formState before render to subscribe the form state through the Proxy
-    formState: { errors, isDirty, isSubmitting, touched, submitCount },
+    formState: { errors, isDirty, isSubmitting, touchedFields, submitCount },
   } = useForm();
   const onSubmit = (data: FormInputs) => console.log(data);
 

--- a/src/components/codeExamples/formStateTs.ts
+++ b/src/components/codeExamples/formStateTs.ts
@@ -10,7 +10,7 @@ export default function App() {
     register,
     handleSubmit,
     // Read the formState before render to subscribe the form state through Proxy
-    formState: { errors, isDirty, isSubmitting, touched, submitCount },
+    formState: { errors, isDirty, isSubmitting, touchedFields, submitCount },
   } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => console.log(data);
 

--- a/src/components/codeExamples/formStateUseEffect.ts
+++ b/src/components/codeExamples/formStateUseEffect.ts
@@ -11,7 +11,7 @@ export default function App () {
   const onSubmit = (data) => console.log(data);
 
   React.useEffect(() => {
-    console.log("touched", formState.touched);
+    console.log("touchedFields", formState.touchedFields);
   },[formState]); // use entire formState object as optional array arg in useEffect, not individual properties of it
 
 

--- a/src/components/codeExamples/formStateUseEffect.ts
+++ b/src/components/codeExamples/formStateUseEffect.ts
@@ -5,7 +5,7 @@ export default function App () {
   const {
     register,
     handleSubmit,
-    formState: { touched }
+    formState
   } = useForm();
 
   const onSubmit = (data) => console.log(data);

--- a/src/components/codeExamples/formStateUseEffectTs.ts
+++ b/src/components/codeExamples/formStateUseEffectTs.ts
@@ -7,7 +7,7 @@ export default function App() {
   const {
     register,
     handleSubmit,
-    formState: { touched }
+    formState
   } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => console.log(data);
   

--- a/src/components/codeExamples/formStateUseEffectTs.ts
+++ b/src/components/codeExamples/formStateUseEffectTs.ts
@@ -12,7 +12,7 @@ export default function App() {
   const onSubmit = (data: FormInputs) => console.log(data);
   
   React.useEffect(() => {
-    console.log("touched", formState.touched);
+    console.log("touchedFields", formState.touchedFields);
   }, [formState]);
   
   return (


### PR DESCRIPTION
There are remaining `touched` keywords which is used in v6 and replaced with `touchedFields` in v7. Also in code examples formState is being destructured to touched by `formState: { touched }`  and then trying to reach the `formState`. It is not possible after destructuring. This PR fixes those issues.