### PR TITLE
Fix Scroll Behaviour

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -355,12 +355,12 @@ table {
 .scrollToTop,
 .scrollToTop:focus {
   border: 1px solid var(--color-light-grey);
-  display: none;
 }
 
 .editPage:hover,
 .scrollToTop:hover {
   border-color: var(--color-secondary);
+  cursor: pointer;
 }
 
 .desktopOnly {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -78,7 +78,13 @@ const Layout = (props: {
         <button
           className="scrollToTop"
           aria-label="Scroll back to top"
-          onClick={() => window.scrollTo(0, 0)}
+          onClick={() =>
+            window.scrollTo({
+              top: 0,
+              left: 0,
+              behavior: "smooth",
+            })
+          }
         >
           ▲
         </button>


### PR DESCRIPTION
# Description

Turns out that on focus, the button was set to `display: none` and hence, as soon as the user used to click, the button's focus state turned active and it was removed from DOM, therefore, leaving the click operation _"hanging"_.

## Other Information

- I tested the change in Firefox Developer Edition + Brave Browser.
- I have changed the cursor to `pointer` to increase interactivity.
- fixes #617 