### PR TITLE
Import v6 code examples from v6 folder

### DIFF
--- a/src/components/v6/ControllerContentV6.tsx
+++ b/src/components/v6/ControllerContentV6.tsx
@@ -1,12 +1,12 @@
 import * as React from "react"
 import CodeArea from "../CodeArea"
-import controller from "../codeExamples/controller"
+import controller from "../codeExamples/v6/controller"
 import reactNativeController from "../codeExamples/reactNativeController"
 import generic from "../../data/generic"
 import TabGroup from "../TabGroup"
 import * as typographyStyles from "../../styles/typography.module.css"
 import * as tableStyles from "../../styles/table.module.css"
-import controllerTs from "../codeExamples/controllerTs"
+import controllerTs from "../codeExamples/v6/controllerTs"
 
 export default function ControllerContentV6({
   currentLanguage,


### PR DESCRIPTION
In V6 API, controller section code examples are exported from v7 code examples. This PR fixes those imports.