### PR TITLE
fix useForm.setError "shouldFocus" documentation

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -1232,7 +1232,7 @@ reset({ deepNest: { file: new File() } });
           </li>
           <li>
             <p>
-              <code>shouldFocusError</code> doesn't work when an input has been
+              <code>shouldFocus</code> doesn't work when an input has been
               disabled.
             </p>
           </li>
@@ -1245,7 +1245,6 @@ reset({ deepNest: { file: new File() } });
             <tbody>
               <tr>
                 <th>Name</th>
-                <th></th>
                 <th width={"200px"}>Type</th>
                 <th>Description</th>
               </tr>
@@ -1253,7 +1252,6 @@ reset({ deepNest: { file: new File() } });
                 <td>
                   <code>name</code>
                 </td>
-                <td></td>
                 <td>
                   <code className={typographyStyles.typeText}>string</code>
                 </td>
@@ -1265,7 +1263,6 @@ reset({ deepNest: { file: new File() } });
                 <td>
                   <code>error</code>
                 </td>
-                <td></td>
                 <td>
                   <code
                     className={typographyStyles.typeText}
@@ -1278,10 +1275,9 @@ reset({ deepNest: { file: new File() } });
               <tr>
                 <td>config</td>
                 <td>
-                  <code>shouldFocus</code>
-                </td>
-                <td>
-                  <code className={typographyStyles.typeText}>boolean</code>
+                  <code
+                    className={typographyStyles.typeText}
+                  >{`{ shouldFocus?: boolean }`}</code>
                 </td>
                 <td>
                   <p>


### PR DESCRIPTION
relates to #622 

I recently upgraded from `^6.15.4` to `^7.8.8` and followed [the v6 -> v7 migration guide](https://react-hook-form.com/migrate-v6-to-v7/).
The guide highlights that `setError` now accepts a config object `{ shouldFocus?: true }` rather than a boolean.
<img width="1325" alt="Screen Shot 2021-06-23 at 3 50 42 PM" src="https://user-images.githubusercontent.com/17504407/123290927-a5d61b80-d4df-11eb-9ff8-53499d5be301.png">
This PR updates the v7 documentation for `setError` per that change.

Current Documentation | This Change
-|-
<img width="1253" alt="Screen Shot 2021-06-24 at 11 13 07 AM" src="https://user-images.githubusercontent.com/17504407/123291540-31e84300-d4e0-11eb-8527-66db2c8c9e4f.png">|<img width="1253" alt="Screen Shot 2021-06-24 at 11 10 46 AM" src="https://user-images.githubusercontent.com/17504407/123291541-31e84300-d4e0-11eb-9108-819ce9cfba78.png">