### PR TITLE
fix: minor keepError typo fix

### DIFF
--- a/src/components/useForm/UnRegister.tsx
+++ b/src/components/useForm/UnRegister.tsx
@@ -122,7 +122,7 @@ export default ({ currentLanguage }) => {
                   </tr>
                   <tr>
                     <td>
-                      <code>keepErrors</code>
+                      <code>keepError</code>
                     </td>
                     <td>
                       <span className={typographyStyles.typeText}>boolean</span>


### PR DESCRIPTION
#628 

I found this typo when going through the docs today. I created the above issue and heres the PR for it since its so small. 