### PR TITLE
[PT-BR docs] Update Testing form docs section on advanced page

### DIFF
--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -374,7 +374,7 @@ export default {
       <>
         <p>
           Os testes são muito importantes porque preservam o código de bugs ou
-          erros e garantir a segurança do código quando você refatorar a base de
+          erros e garantem a segurança do código quando você refatorar a base de
           código.
         </p>
 
@@ -394,8 +394,7 @@ export default {
         <p style={{ textAlign: "center" }}>♦</p>
 
         <p>
-          <b className={typographyStyles.note}>Step 1:</b> Prepare seus testes
-          ambiente.
+          <b className={typographyStyles.note}>Step 1:</b> Prepare seu ambiente de testes.
         </p>
 
         <p>


### PR DESCRIPTION
I've adjusted some typos and words but I saw that this page is completely different, maybe I can compare with live english version and update all content?

PT: [https://react-hook-form.com/pt/advanced-usage/#TestingForm](https://react-hook-form.com/pt/advanced-usage/#TestingForm)

EN: [https://react-hook-form.com/advanced-usage/#TestingForm](https://react-hook-form.com/advanced-usage/#TestingForm)

Example, look into "Set up your testing environment" section, on pt version is listed mutationobserver-shim, on english version there's no mention about this.