### PR TITLE
Fix typo in the modal question of FAQ

### DIFF
--- a/src/components/codeExamples/controlled.ts
+++ b/src/components/codeExamples/controlled.ts
@@ -28,7 +28,7 @@ function App() {
         value={firstName}
       />
 
-      <input onChange={(e) => handleChange("lastName", e)} value={lastName} />
+      <input onChange={(e) => handleChange(e, "lastName")} value={lastName} />
       <input type="submit" />
     </form>
   );


### PR DESCRIPTION
In FAQ's `How to work with modal or tab forms?` 's `Custom Register` tab,
I think the parameter order of calling `handleChange` in the `lastName` field is reversed.