### PR TITLE
React.RefObject -> React.Ref

### DIFF
--- a/src/components/ApiErrors.tsx
+++ b/src/components/ApiErrors.tsx
@@ -87,7 +87,7 @@ export default React.memo(
                 </td>
                 <td>
                   <span className={typographyStyles.typeText}>
-                    React.RefObject
+                    React.Ref
                   </span>
                 </td>
                 <td>{api.errors.ref}</td>

--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -119,7 +119,7 @@ export default function ApiRefTable({
                 <code>ref</code>
                 <br />
                 <code className={typographyStyles.typeText}>
-                  React.RefObject
+                  React.Ref
                 </code>
               </td>
               <td>React element ref</td>

--- a/src/components/UseControllerMethods.tsx
+++ b/src/components/UseControllerMethods.tsx
@@ -84,7 +84,7 @@ export default ({ currentLanguage, isController }) => {
               <code>ref</code>
             </td>
             <tr>
-              <code className={typographyStyles.typeText}>React.RefObject</code>
+              <code className={typographyStyles.typeText}>React.Ref</code>
             </tr>
             <td>
               <p>


### PR DESCRIPTION
Fixes Issue #647. React.Ref is what core uses, and it is just a wrapper around React.RefObject that also includes callback refs & null:
![reactRefExample](https://user-images.githubusercontent.com/35811186/131282445-630c6aa1-b5fd-4e74-9304-801729867929.png)
