### PR TITLE
Space typo

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -405,7 +405,7 @@ export default function ApiRefTable({
                     <p>Only applies to text input.</p>
                   </li>
                   <li>
-                    Does not transform <code>defaultValue</code> or
+                    Does not transform <code>defaultValue</code> or{" "}
                     <code>defaultValues</code>.
                   </li>
                 </ul>
@@ -445,7 +445,7 @@ export default function ApiRefTable({
                     <p>Only applies to text input.</p>
                   </li>
                   <li>
-                    Does not transform <code>defaultValue</code> or
+                    Does not transform <code>defaultValue</code> or{" "}
                     <code>defaultValues</code>.
                   </li>
                 </ul>
@@ -487,7 +487,7 @@ export default function ApiRefTable({
                     <p>Only applies to text input.</p>
                   </li>
                   <li>
-                    Does not transform <code>defaultValue</code> or
+                    Does not transform <code>defaultValue</code> or{" "}
                     <code>defaultValues</code>.
                   </li>
                 </ul>


### PR DESCRIPTION
Looks like there is a space missing:
<img width="292" alt="Screen Shot 2021-09-08 at 4 26 35 PM" src="https://user-images.githubusercontent.com/15869149/132474109-6ec912cb-b7e2-4f3f-8cbe-dc618afa241f.png">


Link: https://react-hook-form.com/api/useform/register/