### PR TITLE
Expand TS -> Typescript

### DIFF
--- a/src/components/tsPage.tsx
+++ b/src/components/tsPage.tsx
@@ -87,10 +87,10 @@ export default ({ defaultLang }: { defaultLang: string }) => {
     <div className={containerStyles.container}>
       <section>
         <h1 className={typographyStyles.headingWithTopMargin} id="main">
-          TS Support
+          Typescript Support
         </h1>
         <p className={typographyStyles.subHeading}>
-          List of exported TS Types.
+          List of exported Typescript Types.
         </p>
       </section>
 

--- a/src/components/v6/tsPageV6.tsx
+++ b/src/components/v6/tsPageV6.tsx
@@ -85,10 +85,10 @@ export default ({ defaultLang }: { defaultLang: string }) => {
     <div className={containerStyles.container}>
       <section>
         <h1 className={typographyStyles.headingWithTopMargin} id="main">
-          TS Support
+          Typescript Support
         </h1>
         <p className={typographyStyles.subHeading}>
-          List of exported TS Types.
+          List of exported Typescript Types.
         </p>
       </section>
 


### PR DESCRIPTION
This will allow Algolia Search to better identify the TS Support Page

*FYI: I tested the change at several different screen sizes and it still formats well 