### PR TITLE
Update example to call with proper argument

### DIFF
--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -122,9 +122,9 @@ export default function UseFieldArray({
 
           <CodeArea
             rawData={`setValue('test', 'data');
-useWatch('test'); // ❌ subscription is happened after value update, no update received
+useWatch({ name: 'test' }); // ❌ subscription is happened after value update, no update received
 
-useWatch('example'); // ✅ input value update will be received and trigger re-render
+useWatch({ name: 'example' }); // ✅ input value update will be received and trigger re-render
 setValue('example', 'data'); 
 `}
           />


### PR DESCRIPTION
Using `useWatch` like the previous example showed would instead provide all the values for all fields.