### PR TITLE
update v7 useForm errors references

### DIFF
--- a/src/components/codeExamples/ErrorCodeTypes.ts
+++ b/src/components/codeExamples/ErrorCodeTypes.ts
@@ -34,7 +34,7 @@ type Inputs = {
   };
 };
 export default function App() {
-  const { errors } = useForm<Inputs>();
+  const { formState: { errors } } = useForm<Inputs>();
   console.log(errors?.a?.message);
   console.log(errors?.b?.message);
   console.log(errors?.c?.message);

--- a/src/components/codeExamples/clearError.ts
+++ b/src/components/codeExamples/clearError.ts
@@ -2,7 +2,7 @@ export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
 const App = () => {
-  const { register, errors, handleSubmit, clearErrors } = useForm();
+  const { register, formState: { errors }, handleSubmit, clearErrors } = useForm();
   const onSubmit = data => console.log(data);
 
   return (

--- a/src/components/codeExamples/clearErrorTs.ts
+++ b/src/components/codeExamples/clearErrorTs.ts
@@ -8,7 +8,7 @@ type FormInputs = {
 };
 
 const App = () => {
-  const { register, errors, handleSubmit, clearErrors } = useForm<FormInputs>();
+  const { register, formState: { errors }, handleSubmit, clearErrors } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {
     console.log(data)

--- a/src/components/codeExamples/errorCode.ts
+++ b/src/components/codeExamples/errorCode.ts
@@ -2,7 +2,7 @@ export default `import React from "react";
 import { useForm } from "react-hook-form";
 
 export default function App() {
-  const { register, errors, handleSubmit } = useForm();
+  const { register, formState: { errors }, handleSubmit } = useForm();
   const onSubmit = data => console.log(data);
 
   return (
@@ -22,7 +22,7 @@ export default function App() {
       {/* register with validation and error message */}
       <input {...register("errorMessage", { required: "This is required" })} />
       {errors.errorMessage?.message}
-      
+
       <input type="submit" />
     </form>
   );

--- a/src/components/codeExamples/errorMessageAdvance.ts
+++ b/src/components/codeExamples/errorMessageAdvance.ts
@@ -3,7 +3,7 @@ import { useForm, useFormContext } from "react-hook-form";
 
 const ErrorMessage = ({ errors, name, messages }) => {
   // Note: if you are using FormContext, then you can use Errors without props eg:
-  // const { errors } = useFormContext();
+  // const { formState: { errors } } = useFormContext();
   if (!errors[name]) return null;
 
   return <p>{messages[errors[name]].message}</p>;
@@ -16,7 +16,7 @@ const messages = {
 };
 
 export default () => {
-  const { register, errors } = useForm();
+  const { register, formState: { errors } } = useForm();
 
   return (
     <form>

--- a/src/components/codeExamples/errorsMessage.ts
+++ b/src/components/codeExamples/errorsMessage.ts
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { ErrorMessage } from '@hookform/error-message';
 
 export default function App() {
-  const { register, errors, handleSubmit } = useForm({
+  const { register, formState: { errors }, handleSubmit } = useForm({
     criteriaMode "all"
   });
   const onSubmit = data => console.log(data);

--- a/src/components/codeExamples/errorsMessageTs.ts
+++ b/src/components/codeExamples/errorsMessageTs.ts
@@ -7,7 +7,7 @@ interface FormInputs {
 }
 
 export default function App() {
-  const { register, errors, handleSubmit } = useForm<FormInputs>({
+  const { register, formState: { errors }, handleSubmit } = useForm<FormInputs>({
     criteriaMode "all"
   });
   const onSubmit = (data: FormInputs) => console.log(data);

--- a/src/components/codeExamples/handleSubmitAsyncCode.ts
+++ b/src/components/codeExamples/handleSubmitAsyncCode.ts
@@ -4,7 +4,7 @@ import { useForm } from "react-hook-form";
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 function App() {
-  const { register, handleSubmit, errors, formState } = useForm();
+  const { register, handleSubmit, formState: { errors }, formState } = useForm();
   const onSubmit = async data => {
     await sleep(2000);
     if (data.username === "bill") {

--- a/src/components/codeExamples/joiResolverTs.ts
+++ b/src/components/codeExamples/joiResolverTs.ts
@@ -14,7 +14,7 @@ const schema = Joi.object({
 });
 
 const App = () => {
-  const { register, handleSubmit, errors } = useForm<IFormInput>({
+  const { register, handleSubmit, formState: { errors } } = useForm<IFormInput>({
     resolver: joiResolver(schema)
   });
   const onSubmit = (data: IFormInput) => {

--- a/src/components/codeExamples/multipleErrorCodeTs.ts
+++ b/src/components/codeExamples/multipleErrorCodeTs.ts
@@ -6,7 +6,7 @@ interface IFormInputs {
 }
 
 export default function App() {
-  const { register, errors, handleSubmit } = useForm<IFormInputs>({
+  const { register, formState: { errors }, handleSubmit } = useForm<IFormInputs>({
     // by setting criteriaMode to 'all',
     // all validation errors for single field will display at once
     criteriaMode: "all",

--- a/src/components/codeExamples/reactHookFormCode.ts
+++ b/src/components/codeExamples/reactHookFormCode.ts
@@ -2,7 +2,7 @@ export default `import React from "react";
 import { useForm } from "react-hook-form";
 
 const Example = () => {
-  const { handleSubmit, register, errors } = useForm();
+  const { handleSubmit, register, formState: { errors } } = useForm();
   const onSubmit = values => console.log(values);
 
   return (

--- a/src/components/codeExamples/setErrorTs.ts
+++ b/src/components/codeExamples/setErrorTs.ts
@@ -6,11 +6,11 @@ type FormInputs = {
 };
 
 const App = () => {
-  const { register, handleSubmit, setError, errors } = useForm<FormInputs>();
+  const { register, handleSubmit, setError, formState: { errors } } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => {
     console.log(data)
   };
-  
+
   React.useEffect(() => {
     setError("username", {
       type: "manual",
@@ -22,7 +22,7 @@ const App = () => {
     <form onSubmit={handleSubmit(onSubmit)}>
       <input {...register("username")} />
       {errors.username && <p>{errors.username.message}</p>}
-      
+
       <input type="submit" />
     </form>
   );

--- a/src/components/codeExamples/setMultipleErrorsTs.ts
+++ b/src/components/codeExamples/setMultipleErrorsTs.ts
@@ -7,7 +7,7 @@ type FormInputs = {
 };
 
 const App = () => {
-  const { register, handleSubmit, setError, errors } = useForm<FormInputs>();
+  const { register, handleSubmit, setError, formState: { errors } } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {
     console.log(data)

--- a/src/components/codeExamples/trigger.ts
+++ b/src/components/codeExamples/trigger.ts
@@ -2,7 +2,7 @@ export default `import React from "react";
 import { useForm } from "react-hook-form";
 
 export default function App() {
-  const { register, trigger, errors } = useForm();
+  const { register, trigger, formState: { errors } } = useForm();
 
   return (
     <form>

--- a/src/components/codeExamples/triggerTs.ts
+++ b/src/components/codeExamples/triggerTs.ts
@@ -7,7 +7,7 @@ type FormInputs = {
 }
 
 export default function App() {
-  const { register, trigger, errors } = useForm<FormInputs>();
+  const { register, trigger, formState: { errors } } = useForm<FormInputs>();
 
   return (
     <form>

--- a/src/components/codeExamples/validationResolverTs.tsx
+++ b/src/components/codeExamples/validationResolverTs.tsx
@@ -15,7 +15,7 @@ const validationSchema = Joi.object({
 });
 
 const App = () => {
-  const { register, handleSubmit, errors } = useForm<IFormInputs>({
+  const { register, handleSubmit, formState: { errors } } = useForm<IFormInputs>({
     resolver: async data => {
       const { error, value: values } = validationSchema.validate(data, {
         abortEarly: false


### PR DESCRIPTION
Updated any `const { errors } = useForm();` to `const { formState: { errors } } = useForm();` in the code examples.

Did not perform the update to any of the files in the v6 directory.