### PR TITLE
Added a more visible search

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -37,7 +37,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
   const { width } = useWindowSize()
 
   React.useEffect(() => {
-    if (1650 < width) {
+    if (1650 <= width) {
       setLang(true)
     } else {
       if (isFocusOnSearch) {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -12,6 +12,7 @@ import Search from "./Search"
 import * as styles from "./Nav.module.css"
 import colors from "../styles/colors"
 import { updateSetting } from "../actions/settingActions"
+import useWindowSize from "./utils/useWindowSize"
 
 export default function Nav({ defaultLang }: { defaultLang: string }) {
   const {
@@ -33,13 +34,21 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
 
   const isFocusOnSearch = setting?.isFocusOnSearch
 
+  const { width } = useWindowSize()
+
   React.useEffect(() => {
-    if (isFocusOnSearch) {
-      setLang(false)
-    } else if (!isFocusOnSearch) {
+    if (1650 < width) {
       setLang(true)
+    } else {
+      if (isFocusOnSearch) {
+        setLang(false)
+      } else if (!isFocusOnSearch) {
+        setLang(true)
+      }
     }
-  }, [isFocusOnSearch])
+  }, [isFocusOnSearch, width])
+
+  console.log(width)
 
   return (
     <>

--- a/src/components/Search.module.css
+++ b/src/components/Search.module.css
@@ -18,11 +18,14 @@
   cursor: pointer;
 }
 
-.searchBar:focus {
-  outline: none;
-  width: 150px;
-  border: 1px solid var(--color-light-pink);
+.searchBarOpen {
   padding: 3px 14px;
+  width: 150px;
+}
+
+.searchBarOpen:focus {
+  outline: none;
+  border: 1px solid var(--color-light-pink);
   cursor: default;
 }
 

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -2,20 +2,18 @@ import * as React from "react"
 import { useStateMachine } from "little-state-machine"
 import { updateSetting } from "../actions/settingActions"
 import * as searchStyles from "./Search.module.css"
+import useWindowSize from "./utils/useWindowSize"
 
 const Search = () => {
   const timer = React.useRef<any>({})
   const { actions, state } = useStateMachine({ updateSetting })
+  const { width } = useWindowSize()
 
   React.useEffect(() => {
     window.docsearch({
       apiKey: "953c771d83fb6ffd55fe58da997f2d9d",
       indexName: "react-hook-form",
       inputSelector: "#algolia-doc-search",
-    })
-
-    actions.updateSetting({
-      isFocusOnSearch: false,
     })
 
     return () => {
@@ -26,11 +24,25 @@ const Search = () => {
     }
   }, [])
 
+  React.useEffect(() => {
+    if (1650 <= width) {
+      actions.updateSetting({
+        isFocusOnSearch: true,
+      })
+    } else {
+      actions.updateSetting({
+        isFocusOnSearch: false,
+      })
+    }
+  }, [width])
+
   return (
     <>
       <form className={searchStyles.searchForm}>
         <input
-          className={searchStyles.searchBar}
+          className={`${searchStyles.searchBar} ${
+            state.setting?.isFocusOnSearch ? searchStyles.searchBarOpen : null
+          }`}
           spellCheck="false"
           type="search"
           aria-label="search input"
@@ -51,13 +63,13 @@ const Search = () => {
           }
           onBlur={() => {
             timer.current && clearTimeout(timer.current)
-            timer.current = setTimeout(
-              () =>
+            timer.current = setTimeout(() => {
+              if (1650 > width) {
                 actions.updateSetting({
                   isFocusOnSearch: false,
-                }),
-              310
-            )
+                })
+              }
+            }, 310)
           }}
         />
         {!state.setting?.isFocusOnSearch && (

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -8,6 +8,7 @@ const Search = () => {
   const timer = React.useRef<any>({})
   const { actions, state } = useStateMachine({ updateSetting })
   const { width } = useWindowSize()
+  const searchRef = React.useRef(null)
 
   React.useEffect(() => {
     window.docsearch({
@@ -33,6 +34,7 @@ const Search = () => {
       actions.updateSetting({
         isFocusOnSearch: false,
       })
+      searchRef.current.blur()
     }
   }, [width])
 
@@ -47,6 +49,7 @@ const Search = () => {
           type="search"
           aria-label="search input"
           id="algolia-doc-search"
+          ref={searchRef}
           {...(state.setting?.isFocusOnSearch
             ? {
                 placeholder: "Search ...",

--- a/src/components/utils/useWindowSize.ts
+++ b/src/components/utils/useWindowSize.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react"
+
+interface Size {
+  width: number | undefined
+  height: number | undefined
+}
+
+export default function useWindowSize(): Size {
+  const [windowSize, setWindowSize] = useState<Size>({
+    width: undefined,
+    height: undefined,
+  })
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      })
+    }
+
+    window.addEventListener("resize", handleResize)
+
+    handleResize()
+
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
+
+  return windowSize
+}


### PR DESCRIPTION
Based on this userfeed back the search wasn't visible enough

![sdsdsdsdsd - Copy](https://user-images.githubusercontent.com/54803528/135867741-b483eea7-c4a3-45d1-9599-780ef66437ab.PNG)

The search is now open on large monitors, and automatically becomes smaller when the screen size is made smaller, also keeps the darkmode and version + language options open on large monitors.