### PR TITLE
docs: fixed missing render props in multiple ErrorMessage examples

### DIFF
--- a/src/components/codeExamples/errorsMessage.ts
+++ b/src/components/codeExamples/errorsMessage.ts
@@ -23,14 +23,16 @@ export default function App() {
           }
         })}
       />
-      <ErrorMessage errors={errors} name="multipleErrorInput">
-        {({ messages }) =>
+      <ErrorMessage
+        errors={errors}
+        name="multipleErrorInput"
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <p key={type}>{message}</p>
           ))
         }
-      </ErrorMessage>
+      />
 
       <input type="submit" />
     </form>

--- a/src/components/codeExamples/errorsMessageTs.ts
+++ b/src/components/codeExamples/errorsMessageTs.ts
@@ -27,14 +27,16 @@ export default function App() {
           }
         })}
       />
-      <ErrorMessage errors={errors} name="multipleErrorInput">
-        {({ messages }) =>
+      <ErrorMessage
+        errors={errors}
+        name="multipleErrorInput"
+        render={({ messages }) =>
           messages &&
           Object.entries(messages).map(([type, message]) => (
             <p key={type}>{message}</p>
           ))
         }
-      </ErrorMessage>
+      />
 
       <input type="submit" />
     </form>


### PR DESCRIPTION
Assume I made a mistake, because the examples are inside a string literal.