### PR TITLE
docs: Fix translation of topic titles

### DIFF
--- a/src/data/pt/advanced.tsx
+++ b/src/data/pt/advanced.tsx
@@ -336,7 +336,7 @@ export default {
     ),
   },
   workingWithVirtualizedList: {
-    title: "Working with virtualized list",
+    title: "Trabalhando com lista virtualizada",
     description: (
       <>
         <p>
@@ -369,7 +369,7 @@ export default {
     ),
   },
   testingForm: {
-    title: "Testing Form",
+    title: "Testando formulário",
     description: (
       <>
         <p>


### PR DESCRIPTION
Just a little translate fix to ptBr doc