### PR TITLE
[docs] `register()` wording clarity

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -532,14 +532,14 @@ const onClick = () => {
         <ul>
           <li>
             <p>
-              It is <b>required</b> and <b>unique</b> (except native radio and
+              <code>name</code> is <b>required</b> and <b>unique</b> (except native radio and
               checkbox). Input name supports both dot and bracket syntax, which
               allows you to easily create nested form fields.
             </p>
           </li>
           <li>
             <p>
-              It can neither start with a number nor use number as key name.
+              <code>name</code> can neither start with a number nor use number as key name.
             </p>
           </li>
           <li>


### PR DESCRIPTION
"It" is ambiguous in this context.  Replacing with the explicit field value being discussed (`name`)