### PR TITLE
fix: about-us barrymay url

### DIFF
--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -33,7 +33,7 @@ const data = [
   {
     name: "Barry May",
     imgUrl: "https://avatars.githubusercontent.com/u/5514034?v=4",
-    url: "https://github.com/stramel",
+    url: "https://github.com/barrymay",
     bio:
       "I'm a software engineer/team leader with long-term UI/UX and DevOps experience.  I love to show devs the power of the modern web stack (TypeScript in particular 😀), and I'm thrilled to assist on great OSS projects like react-hook-form!",
     twitterName: "barry_a_may",


### PR DESCRIPTION
The url was wrong for https://github.com/barrymay on the about us page.