### PR TITLE
Fix incorrect property name for fieldState.error

### DIFF
--- a/src/components/useForm/GetFieldState.tsx
+++ b/src/components/useForm/GetFieldState.tsx
@@ -169,7 +169,7 @@ getFieldState('test', formState); // ✅ register input and return field state
                   </tr>
                   <tr>
                     <td>
-                      <p>invalid</p>
+                      <p>error</p>
                     </td>
                     <td>
                       <code className={typographyStyles.typeText}>


### PR DESCRIPTION
Seems like this was copied from the previous item (`invalid`).