### PR TITLE
fix: added the definition of handleClick

### DIFF
--- a/src/components/codeExamples/resetFieldCode.ts
+++ b/src/components/codeExamples/resetFieldCode.ts
@@ -12,6 +12,7 @@ export default function App() {
       firstName: ""
     }
   });
+  const handleClick = () => resetField("firstName");
 
   return (
     <form>


### PR DESCRIPTION
In the code example of [resetField](https://react-hook-form.com/api/useform/resetfield), the definition of handleClick was missing, so I added it.
Fixed to match the code in [CDB](https://codesandbox.io/s/resetfield-with-options-iw4wd).