### PR TITLE
Update:missing colon

### DIFF
--- a/src/components/codeExamples/errorsMessageTs.ts
+++ b/src/components/codeExamples/errorsMessageTs.ts
@@ -8,7 +8,7 @@ interface FormInputs {
 
 export default function App() {
   const { register, formState: { errors }, handleSubmit } = useForm<FormInputs>({
-    criteriaMode "all"
+    criteriaMode: "all"
   });
   const onSubmit = (data: FormInputs) => console.log(data);
 


### PR DESCRIPTION
Due to a lack of colons, the following error has been fixed.

```
Failed to compile.

SyntaxError: /Users/program/src/components/pages/SignUp.js: Unexpected token, expected "," (7:17)
   5 | export default function App() {
   6 |   const { register, formState: { errors }, handleSubmit } = useForm({
>  7 |     criteriaMode "all"
     |                  ^
   8 |   });
   9 |   const onSubmit = data => console.log(data);
  10 |
```