### PR TITLE
Add description of undefined onChange to useController documentation

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -2151,7 +2151,9 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅ sugar syntax t
               </li>
               <li>
                 <p>
-                  Calling <code>onChange</code> with <code>undefined</code> is undefined behavior, and may change based on value type or minor/patch version. You should use <code>null</code> or the empty string as your default/cleared value instead.
+                  Calling <code>onChange</code> with <code>undefined</code> is
+                  not valid. You should use <code>null</code> or the empty
+                  string as your default/cleared value instead.
                 </p>
               </li>
             </ul>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -2149,6 +2149,11 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅ sugar syntax t
                   <code>defaultValues</code>.
                 </p>
               </li>
+              <li>
+                <p>
+                  Calling <code>onChange</code> with <code>undefined</code> clears the controlled form field..
+                </p>
+              </li>
             </ul>
           </td>
         </tr>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -2151,7 +2151,7 @@ setValue('notRegisteredInput', { test: '1', test2: '2' }); // ✅ sugar syntax t
               </li>
               <li>
                 <p>
-                  Calling <code>onChange</code> with <code>undefined</code> clears the controlled form field..
+                  Calling <code>onChange</code> with <code>undefined</code> is undefined behavior, and may change based on value type or minor/patch version. You should use <code>null</code> or the empty string as your default/cleared value instead.
                 </p>
               </li>
             </ul>


### PR DESCRIPTION
Explicitly state that calling `onChange` with `undefined` will clear the named field when using `useController`.

This is a useful operation, since some types of form inputs, such as number input, can be cleared in a way which means something different than any allowable value.