### PR TITLE
Docs: Add default values to reset options

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -894,6 +894,7 @@ handleSubmit(async (data) => await fetchAPI(data))`}
               <tr>
                 <th>{generic.name.en}</th>
                 <th>{generic.type.en}</th>
+                <th>{generic.default.en}</th>
                 <th>{generic.description.en}</th>
               </tr>
             </thead>
@@ -905,6 +906,7 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                 <td>
                   <code className={typographyStyles.typeText}>object</code>
                 </td>
+                <td></td>
                 <td>
                   <p>An optional object to reset form values.</p>
                 </td>
@@ -914,7 +916,10 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                   <code>keepErrors</code>
                 </td>
                 <td>
-                  <code className={typographyStyles.typeText}>boolean</code>
+                  <code className={typographyStyles.typeText}>object</code>
+                </td>
+                <td>
+                  <code>false</code>
                 </td>
                 <td>
                   <p>
@@ -929,6 +934,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                 </td>
                 <td>
                   <code className={typographyStyles.typeText}>boolean</code>
+                </td>
+                <td>
+                  <code>false</code>
                 </td>
                 <td>
                   <p>
@@ -952,6 +960,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                   <code className={typographyStyles.typeText}>boolean</code>
                 </td>
                 <td>
+                  <code>false</code>
+                </td>
+                <td>
                   <p>Form input values will be unchanged.</p>
                 </td>
               </tr>
@@ -961,6 +972,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                 </td>
                 <td>
                   <code className={typographyStyles.typeText}>boolean</code>
+                </td>
+                <td>
+                  <code>false</code>
                 </td>
                 <td>
                   <p>
@@ -993,6 +1007,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                   <code className={typographyStyles.typeText}>boolean</code>
                 </td>
                 <td>
+                  <code>false</code>
+                </td>
+                <td>
                   <p>
                     <code>isSubmitted</code> state will be unchanged.
                   </p>
@@ -1004,6 +1021,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                 </td>
                 <td>
                   <code className={typographyStyles.typeText}>boolean</code>
+                </td>
+                <td>
+                  <code>false</code>
                 </td>
                 <td>
                   <p>
@@ -1019,6 +1039,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                   <code className={typographyStyles.typeText}>boolean</code>
                 </td>
                 <td>
+                  <code>false</code>
+                </td>
+                <td>
                   <p>
                     <code>isValid</code> will temporarily persist as the current
                     state until additional user actions.
@@ -1031,6 +1054,9 @@ handleSubmit(async (data) => await fetchAPI(data))`}
                 </td>
                 <td>
                   <code className={typographyStyles.typeText}>boolean</code>
+                </td>
+                <td>
+                  <code>false</code>
                 </td>
                 <td>
                   <p>

--- a/src/data/generic.tsx
+++ b/src/data/generic.tsx
@@ -202,6 +202,9 @@ export default {
     zh: "类型",
     ru: "Тип",
   },
+  default: {
+    en: "Default",
+  },
   description: {
     en: "Description",
     es: "Descripción",


### PR DESCRIPTION
I would like to add default values for the `options` object that can be passed to the `reset` function as a parameter. 

Today, I was trying to find out what are the default values for all the possible atributes in the `options` objects and it took me a while to find it in the source code. 

I believe that it can be helpful to include default values in the docs as well.