### PR TITLE
support live editing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "beier luo",
   "dependencies": {
     "@hookform/devtools": "2.0.0-beta.1",
+    "@hookform/error-message": "^2.0.0",
     "gatsby": "^3.3.0",
     "gatsby-plugin-algolia-docsearch": "^1.0.5",
     "gatsby-plugin-google-analytics": "3.3.0",
@@ -27,7 +28,10 @@
     "react-github-btn": "1.2.0",
     "react-helmet": "6.1.0",
     "react-hook-form": "6.0.0-rc.1",
+    "react-hook-form-v7": "npm:react-hook-form@7",
+    "react-runner": "^1.0.0",
     "react-simple-animate": "^3.3.12",
+    "react-simple-code-editor": "^0.11.0",
     "react-simple-img": "2.3.9",
     "react-sortablejs": "1.5.1",
     "sortablejs": "1.10.2"

--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -762,6 +762,7 @@ register('test', { required: false });  // ✅
         </h2>
 
         <CodeArea
+          canEdit
           rawData={register}
           url="https://codesandbox.io/s/react-hook-form-js-wbybv"
           tsRawData={registerTs}

--- a/src/components/ApiWatch.tsx
+++ b/src/components/ApiWatch.tsx
@@ -173,12 +173,14 @@ export default function ApiWatch({
 
       <TabGroup buttonLabels={["Form", "Advance Field Array"]}>
         <CodeArea
+          canEdit
           rawData={watchCode}
           tsRawData={watchCodeTs}
           url="https://codesandbox.io/s/react-hook-form-watch-v7-qbxd7"
           tsUrl="https://codesandbox.io/s/react-hook-form-watch-v7-ts-8et1d"
         />
         <CodeArea
+          canEdit
           rawData={watchFieldArrayCode}
           url="https://codesandbox.io/s/watch-with-usefieldarray-e2d64"
         />

--- a/src/components/CodeArea.module.css
+++ b/src/components/CodeArea.module.css
@@ -38,21 +38,21 @@
   }
 }
 
-.copyButton {
+.editButton {
   background: none;
   border: 1px solid transparent;
   color: currentColor;
 }
 
 .active,
-.copyButton:hover {
+.editButton:hover {
   background: none;
   border: 1px solid var(--color-secondary);
   color: white;
 }
 
 .active,
-.copyButton:hover span {
+.editButton:hover span {
   background: var(--color-primary);
 }
 
@@ -74,10 +74,54 @@
   line-height: 1.5 !important;
 }
 
-.wrapper pre code {
-  display: none;
+.liveRunner {
+  overflow: hidden;
+  margin: 14px 0;
+  padding: 15px;
+  background: var(--color-purple);
 }
 
-.wrapper pre code.showCode {
-  display: block;
+:global(.light) .liveRunner {
+  background: #fff;
+  border: 1px solid var(--color-light-grey);
+}
+
+.editorWrapper {
+  overflow: auto;
+  background: inherit;
+  color: inherit;
+}
+
+.editor {
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+  word-wrap: normal;
+  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+  font-size: 14px;
+  text-shadow: none;
+
+  white-space: pre;
+  min-width: 100%;
+  float: left;
+  background: inherit;
+  color: inherit;
+  line-height: 1.5;
+}
+
+.editor > textarea,
+.editor > pre {
+  outline: none;
+  white-space: pre !important;
+}
+
+.liveError {
+  color: var(--color-secondary);
+  border: 1px solid var(--color-secondary) !important;
+  white-space: pre-wrap;
+  padding: 15px;
 }

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import Prism from "prismjs"
+import * as styles from "./CodeArea.module.css"
+
+export const CodeBlock = ({
+  children,
+  style,
+}: {
+  children: string
+  style?: React.CSSProperties
+}) => (
+  <div className={styles.wrapper}>
+    <pre className="raw-code language-javascript" style={style} tabIndex={0}>
+      <code
+        className="language-javascript"
+        dangerouslySetInnerHTML={{
+          __html: Prism.highlight(children, Prism.languages.javascript),
+        }}
+      />
+    </pre>
+  </div>
+)

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -146,12 +146,16 @@ export default ({
                 ]}
               >
                 <CodeArea
+                  // there will be error as we are using HookForm V6 in this app
+                  // and `@hookform/error-message` will use that version but `get` is not available
+                  // canEdit
                   rawData={errorMessage}
                   url="https://codesandbox.io/s/react-hook-form-v7-errormessage-jufsl"
                   tsRawData={errorMessageTs}
                   tsUrl="https://codesandbox.io/s/react-hook-form-v7-ts-errormessage-d1ues"
                 />
                 <CodeArea
+                  // canEdit
                   rawData={errorsMessage}
                   url="https://codesandbox.io/s/react-hook-form-v7-errormessage-multiple-error-messages-lnvkt"
                   tsRawData={errorsMessageTs}

--- a/src/components/FormContext.tsx
+++ b/src/components/FormContext.tsx
@@ -64,6 +64,7 @@ export default function FormContext({ currentLanguage, api }) {
       </h2>
 
       <CodeArea
+        canEdit
         rawData={formContext}
         url="https://codesandbox.io/s/react-hook-form-v7-form-context-ytudi"
       />

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -57,6 +57,7 @@ export default function GetStarted({
       </h2>
       <p>{getStarted.example.description}</p>
       <CodeArea
+        canEdit
         rawData={isV7 ? code : codeV6}
         tsRawData={isV7 ? codeTs : codeTsV6}
         url={

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -235,6 +235,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.register.description}
 
           <CodeArea
+            canEdit
             rawData={isV7 ? registerCode : v6Example.registerCode}
             tsRawData={isV7 ? registerCodeTs : v6Example.registerCodeTs}
             url={
@@ -264,6 +265,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.applyValidation.description(currentLanguage)}
 
           <CodeArea
+            canEdit
             rawData={isV7 ? applyValidation : v6Example.applyValidation}
             url={
               isV7
@@ -293,6 +295,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.adapting.description}
 
           <CodeArea
+            canEdit
             rawData={isV7 ? migrateCode : v6Example.migrateCode}
             url="https://codesandbox.io/s/react-hook-form-adapting-existing-form-llbnn"
             tsRawData={isV7 ? migrateCodeTs : v6Example.migrateCodeTs}
@@ -364,6 +367,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
               }
             />
             <CodeArea
+              canEdit
               rawData={isV7 ? useController : useControllerV6}
               tsRawData={isV7 ? useControllerTs : useControllerTsV6}
               tsUrl={
@@ -410,6 +414,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.errors.description}
 
           <CodeArea
+            canEdit
             rawData={isV7 ? errors : v6Example.errors}
             url={
               isV7
@@ -497,6 +502,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.reactNative.description}
 
           <CodeArea
+            canEdit
             isExpo
             rawData={isV7 ? reactNativeController : reactNativeControllerV6}
             url={
@@ -521,6 +527,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
           {getStarted.typeScript.description}
 
           <CodeArea
+            canEdit
             rawData={isV7 ? typeScript : typeScriptV6}
             url={
               isV7

--- a/src/components/LiveRunner.tsx
+++ b/src/components/LiveRunner.tsx
@@ -1,0 +1,187 @@
+import * as React from "react"
+import * as HookForm from "react-hook-form-v7"
+import * as ErrorMesssage from "@hookform/error-message"
+import { useRunner } from "react-runner"
+import Editor from "react-simple-code-editor"
+import Prism from "prismjs"
+import { ShadowRoot } from "./ShadowRoot"
+import * as styles from "./CodeArea.module.css"
+
+const scope = {
+  import: {
+    react: React,
+    "react-hook-form": HookForm,
+    "@hookform/error-message": ErrorMesssage,
+  },
+}
+
+console.log(ErrorMesssage)
+
+const previewStyle = `
+body, :host {
+  background: #0e101c;
+  color: #fff;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
+    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  padding: 14px;
+}
+
+form {
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+h1 {
+  font-weight: 100;
+  color: white;
+  text-align: center;
+  padding-bottom: 10px;
+  border-bottom: 1px solid rgb(79, 98, 148);
+}
+
+.form {
+  background: #0e101c;
+  max-width: 400px;
+  margin: 0 auto;
+}
+
+p {
+  color: #bf1650;
+}
+
+p::before {
+  display: inline;
+  content: "⚠ ";
+}
+
+input {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
+  border-radius: 4px;
+  border: 1px solid white;
+  padding: 10px 15px;
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+label {
+  line-height: 2;
+  text-align: left;
+  display: block;
+  margin-bottom: 13px;
+  margin-top: 20px;
+  color: white;
+  font-size: 14px;
+  font-weight: 200;
+}
+
+button[type="submit"],
+input[type="submit"] {
+  background: #ec5990;
+  color: white;
+  text-transform: uppercase;
+  border: none;
+  margin-top: 40px;
+  padding: 20px;
+  font-size: 16px;
+  font-weight: 100;
+  letter-spacing: 10px;
+}
+
+button[type="submit"]:hover,
+input[type="submit"]:hover {
+  background: #bf1650;
+}
+
+button[type="submit"]:active,
+input[type="button"]:active,
+input[type="submit"]:active {
+  transition: 0.3s all;
+  transform: translateY(3px);
+  border: 1px solid transparent;
+  opacity: 0.8;
+}
+
+input:disabled {
+  opacity: 0.4;
+}
+
+input[type="button"]:hover {
+  transition: 0.3s all;
+}
+
+button[type="submit"],
+input[type="button"],
+input[type="submit"] {
+  -webkit-appearance: none;
+}
+
+.App {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+button[type="button"] {
+  display: block;
+  appearance: none;
+  background: #333;
+  color: white;
+  border: none;
+  text-transform: uppercase;
+  padding: 10px 20px;
+  border-radius: 4px;
+}
+
+hr {
+  margin-top: 30px;
+}
+
+button {
+  display: block;
+  appearance: none;
+  margin-top: 40px;
+  border: 1px solid #333;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+  padding: 10px 20px;
+  border-radius: 4px;
+}`
+
+export const LiveRunner = ({
+  initialCode,
+  style,
+}: {
+  initialCode: string
+  style?: React.CSSProperties
+}) => {
+  const [code, setCode] = React.useState(initialCode)
+  const { element, error } = useRunner({ code, scope })
+  React.useEffect(() => {
+    setCode(initialCode)
+  }, [initialCode])
+
+  return (
+    <>
+      <div className={styles.liveRunner} style={style} tabIndex={0}>
+        <div className={styles.editorWrapper}>
+          <Editor
+            value={code}
+            onValueChange={setCode}
+            padding={0}
+            className={styles.editor}
+            highlight={(code) =>
+              Prism.highlight(code, Prism.languages.javascript)
+            }
+          />
+        </div>
+      </div>
+      {error && <pre className={styles.liveError}>{error}</pre>}
+      <ShadowRoot>
+        {element}
+        <style>{previewStyle}</style>
+      </ShadowRoot>
+    </>
+  )
+}

--- a/src/components/ShadowRoot.tsx
+++ b/src/components/ShadowRoot.tsx
@@ -1,0 +1,20 @@
+import * as React from "react"
+import { createPortal } from "react-dom"
+
+export const ShadowRoot: React.FC<JSX.IntrinsicElements["div"]> = ({
+  children,
+  ...rest
+}) => {
+  const ref = React.useRef<HTMLDivElement>(null)
+  const [shadowRoot, setShadowRoot] = React.useState<ShadowRoot>()
+
+  React.useEffect(() => {
+    setShadowRoot(ref.current?.attachShadow({ mode: "open" }))
+  }, [])
+
+  return (
+    <div ref={ref} {...rest}>
+      {shadowRoot && createPortal(children, shadowRoot as any)}
+    </div>
+  )
+}

--- a/src/components/UseFieldArrayContent.tsx
+++ b/src/components/UseFieldArrayContent.tsx
@@ -191,16 +191,18 @@ append({ firstName: 'bill', lastName: 'luo' }); ✅`}
         ]}
       >
         <CodeArea
+          canEdit
           rawData={useFieldArray}
           tsRawData={useFieldArrayTS}
           tsUrl="https://codesandbox.io/s/calc-i231d"
           url="https://codesandbox.io/s/react-hook-form-usefieldarray-ssugn"
         />
         <CodeArea
+          canEdit
           rawData={useFieldArrayConditional}
           url="https://codesandbox.io/s/usefieldarray-conditional-2wi6f"
         />
-        <CodeArea rawData={useFieldArrayFocus} />
+        <CodeArea canEdit rawData={useFieldArrayFocus} />
       </TabGroup>
 
       <>
@@ -234,7 +236,7 @@ const ConditionalInput = ({ control, index, field }) => {
   );
 };
 
-function App() {
+export default function App() {
   const { control, register } = useForm();
   const { fields, append, prepend } = useFieldArray({
     control,

--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -371,7 +371,7 @@ const { register } = useForm<FormInputs>({
               Examples
             </h3>
 
-            <CodeArea rawData={shouldUseNativeValidation} />
+            <CodeArea canEdit rawData={shouldUseNativeValidation} />
 
             <ValidationResolver api={api} />
 

--- a/src/components/UseFormState.tsx
+++ b/src/components/UseFormState.tsx
@@ -145,6 +145,7 @@ const formState = useFormState(); // ❌ should deconstruct the formState
             </h2>
 
             <CodeArea
+              canEdit
               rawData={useFormState}
               url={"https://codesandbox.io/s/useformstate-75xly"}
             />

--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -167,6 +167,7 @@ setValue('example', 'data');
 
       <TabGroup buttonLabels={["Form", "Advance Field Array"]}>
         <CodeArea
+          canEdit
           rawData={useWatch}
           url="https://codesandbox.io/s/react-hook-form-v7-usewatch-forked-9872t"
           tsRawData={useWatchTs}

--- a/src/components/codeExamples/clearError.ts
+++ b/src/components/codeExamples/clearError.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, formState: { errors }, handleSubmit, clearErrors } = useForm();
   const onSubmit = data => console.log(data);
 

--- a/src/components/codeExamples/clearErrorTs.ts
+++ b/src/components/codeExamples/clearErrorTs.ts
@@ -7,7 +7,7 @@ type FormInputs = {
   username: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, formState: { errors }, handleSubmit, clearErrors } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {

--- a/src/components/codeExamples/connectForm.ts
+++ b/src/components/codeExamples/connectForm.ts
@@ -12,7 +12,7 @@ export const DeepNest = () => (
   </ConnectForm>
 );
 
-export const App = () => {
+export export default function App() {
   const methods = useForm();
   
   return (

--- a/src/components/codeExamples/control.ts
+++ b/src/components/codeExamples/control.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import { useForm, Controller } from "react-hook-form";
 
-function App() {
+export default function App() {
   const { control } = useForm();
   
   return (

--- a/src/components/codeExamples/controlled.ts
+++ b/src/components/codeExamples/controlled.ts
@@ -1,7 +1,7 @@
 export default `import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 
-function App() {
+export default function App() {
   const { register, watch, setValue, handleSubmit } = useForm({
     defaultValues: {
       firstName: "",

--- a/src/components/codeExamples/errorsMessage.ts
+++ b/src/components/codeExamples/errorsMessage.ts
@@ -4,7 +4,7 @@ import { ErrorMessage } from '@hookform/error-message';
 
 export default function App() {
   const { register, formState: { errors }, handleSubmit } = useForm({
-    criteriaMode "all"
+    criteriaMode: "all"
   });
   const onSubmit = data => console.log(data);
 

--- a/src/components/codeExamples/formContext.ts
+++ b/src/components/codeExamples/formContext.ts
@@ -6,7 +6,7 @@ export default function App() {
   const onSubmit = data => console.log(data);
 
   return (
-    <FormProvider {...methods} > // pass all methods into the context
+    <FormProvider {...methods} > { /* pass all methods into the context */ }
       <form onSubmit={methods.handleSubmit(onSubmit)}>
         <NestedInput />
         <input type="submit" />

--- a/src/components/codeExamples/getFieldState.ts
+++ b/src/components/codeExamples/getFieldState.ts
@@ -5,7 +5,7 @@ export default function App() {
   const {
     register,
     getFieldState,
-    formState: { isDirty, isValid }
+    formState: { isDirty, dirtyFields, touchedFields, isValid }
   } = useForm({
     mode: "onChange",
     defaultValues: {
@@ -21,7 +21,7 @@ export default function App() {
       <input {...register("firstName", { required: true })} />
       <p>{getFieldState("firstName").isDirty && "dirty"}</p>
       <p>{getFieldState("firstName").isTouched && "touched"}</p>
-      <button type="button" onClick={() => console.log(getFieldState("firstName"))}>
+      <button type="submit" onClick={() => console.log(getFieldState("firstName"))}>
         field state
       </button>
     </form>

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -75,7 +75,7 @@ const Select = React.forwardRef(({ onChange, onBlur, name, label }, ref) => (
   </>
 ));
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm();
 
   const onSubmit = (data) => {
@@ -128,7 +128,7 @@ const Select = React.forwardRef<
   </>
 ));
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<IFormValues>();
 
   const onSubmit: SubmitHandler<IFormValues> = data => {
@@ -207,7 +207,7 @@ import Select from "react-select";
 import { useForm, Controller } from "react-hook-form";
 import Input from "@material-ui/core/Input";
 
-const App = () => {
+export default function App() {
   const { control, handleSubmit } = useForm({
     defaultValues: {
       firstName: '',
@@ -252,7 +252,7 @@ interface IFormInput {
   iceCreamType: {label: string; value: string };
 }
 
-const App = () => {
+export default function App() {
   const { control, handleSubmit } = useForm<IFormInput>();
 
   const onSubmit: SubmitHandler<IFormInput> = data => {
@@ -363,6 +363,8 @@ connect(({ firstName, lastName }) => ({ firstName, lastName }), updateAction)(Yo
 
 export const errors = `import React from "react";
 import { useForm } from "react-hook-form";
+
+const onSubmit = data => console.log(data);
 
 export default function App() {
   const { register, formState: { errors }, handleSubmit } = useForm();

--- a/src/components/codeExamples/handleSubmitAsyncCode.ts
+++ b/src/components/codeExamples/handleSubmitAsyncCode.ts
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
-function App() {
+export default function App() {
   const { register, handleSubmit, formState: { errors }, formState } = useForm();
   const onSubmit = async data => {
     await sleep(2000);
@@ -17,7 +17,7 @@ function App() {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor="username">User Name</label>
-      <input placeholder="Bill" {...register("username"} />
+      <input placeholder="Bill" {...register("username")} />
 
       <input type="submit" />
     </form>

--- a/src/components/codeExamples/joiResolver.tsx
+++ b/src/components/codeExamples/joiResolver.tsx
@@ -8,7 +8,7 @@ const schema = Joi.object({
   age: Joi.string().required(),
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: joiResolver(schema),
   });

--- a/src/components/codeExamples/joiResolverTs.ts
+++ b/src/components/codeExamples/joiResolverTs.ts
@@ -13,7 +13,7 @@ const schema = Joi.object({
   age: Joi.number().required()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, formState: { errors } } = useForm<IFormInput>({
     resolver: joiResolver(schema)
   });

--- a/src/components/codeExamples/setAllErrors.ts
+++ b/src/components/codeExamples/setAllErrors.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm({
     criteriaMode: 'all',
   });

--- a/src/components/codeExamples/setAllErrorsTs.ts
+++ b/src/components/codeExamples/setAllErrorsTs.ts
@@ -5,7 +5,7 @@ type FormInputs = {
   lastName: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm<FormInputs>({
     criteriaMode: 'all',
   });
@@ -19,7 +19,7 @@ const App = () => {
         minLength: "This is minLength"
       }
     });
-  }, [setValue])
+  }, [setError])
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/codeExamples/setError.ts
+++ b/src/components/codeExamples/setError.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm();
   const onSubmit = data => {
     console.log(data)

--- a/src/components/codeExamples/setErrorTs.ts
+++ b/src/components/codeExamples/setErrorTs.ts
@@ -5,7 +5,7 @@ type FormInputs = {
   username: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => {
     console.log(data)

--- a/src/components/codeExamples/setFocus.ts
+++ b/src/components/codeExamples/setFocus.ts
@@ -1,10 +1,9 @@
 export default `import * as React from "react";
-import { useForm } from "./src";
+import { useForm } from "react-hook-form";
 
 export default function App() {
   const { register, handleSubmit, setFocus } = useForm();
   const onSubmit = (data) => console.log(data);
-  renderCount++;
 
   React.useEffect(() => {
     setFocus("firstName");

--- a/src/components/codeExamples/setFocusTs.ts
+++ b/src/components/codeExamples/setFocusTs.ts
@@ -1,5 +1,5 @@
 export default `import * as React from "react";
-import { useForm } from "./src";
+import { useForm } from "react-hook-form";
 
 type FormValues = {
   firstName: string;
@@ -8,7 +8,6 @@ type FormValues = {
 export default function App() {
   const { register, handleSubmit, setFocus } = useForm<FormValues>();
   const onSubmit = (data: FormValues) => console.log(data);
-  renderCount++;
 
   React.useEffect(() => {
     setFocus("firstName");

--- a/src/components/codeExamples/setMultipleErrors.ts
+++ b/src/components/codeExamples/setMultipleErrors.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm();
 
   const onSubmit = data => {

--- a/src/components/codeExamples/setMultipleErrorsTs.ts
+++ b/src/components/codeExamples/setMultipleErrorsTs.ts
@@ -6,7 +6,7 @@ type FormInputs = {
   firstName: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, formState: { errors } } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {

--- a/src/components/codeExamples/setValue.ts
+++ b/src/components/codeExamples/setValue.ts
@@ -1,6 +1,6 @@
 export default `import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, setValue } = useForm();
   
   return (

--- a/src/components/codeExamples/setValueTs.tsx
+++ b/src/components/codeExamples/setValueTs.tsx
@@ -1,6 +1,6 @@
 export default `import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, setValue } = useForm({
     firstName: ''
   });

--- a/src/components/codeExamples/superStructResolver.tsx
+++ b/src/components/codeExamples/superStructResolver.tsx
@@ -8,7 +8,7 @@ const schema = struct({
   age: 'number',
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: superstructResolver(schema),
   });

--- a/src/components/codeExamples/useFieldArray.ts
+++ b/src/components/codeExamples/useFieldArray.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import { useForm, useFieldArray } from "react-hook-form";
 
-function App() {
+export default function App() {
   const { register, control, handleSubmit, reset, trigger, setError } = useForm({
     // defaultValues: {}; you can populate the fields by this attribute 
   });

--- a/src/components/codeExamples/useFieldArrayConditional.ts
+++ b/src/components/codeExamples/useFieldArrayConditional.ts
@@ -58,4 +58,30 @@ const UseFieldArrayUnregister: React.FC = () => {
     </form>
   );
 };
+
+export default function App() {
+  const { control, handleSubmit, register } = useForm<FormValues>({
+    defaultValues: {
+      data: [{ name: "test" }, { name: "test1" }, { name: "test2" }]
+    },
+    mode: "onSubmit"
+  });
+  const { fields } = useFieldArray<{ name: string }>({
+    control,
+    name: "data"
+  });
+  const onSubmit = (data: any) => console.log(data);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      {fields.map((data, index) => (
+        <>
+          <input {...register(\`data.\${index}.name\`)} />
+          <ConditionField register={register} control={control} index={index} />
+        </>
+      ))}
+      <input type="submit" />
+    </form>
+  );
+};
 `

--- a/src/components/codeExamples/useFieldArrayFocus.ts
+++ b/src/components/codeExamples/useFieldArrayFocus.ts
@@ -1,7 +1,7 @@
 export default `import React from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 
-const App = () => {
+export default function App() {
   const { register, control } = useForm<{
     test: { value: string }[];
   }>({

--- a/src/components/codeExamples/useWatch.ts
+++ b/src/components/codeExamples/useWatch.ts
@@ -10,7 +10,7 @@ function Child({ control }) {
   return <p>Watch: {firstName}</p>;
 }
 
-function App() {
+export default function App() {
   const { register, control } = useForm({
     firstName: "test"
   });

--- a/src/components/codeExamples/useWatchTs.ts
+++ b/src/components/codeExamples/useWatchTs.ts
@@ -16,7 +16,7 @@ function FirstNameWatched({ control }: { control: Control<FormInputs> }) {
   return <p>Watch: {firstName}</p>; // only re-render at the custom hook level, when firstName changes
 }
 
-function App() {
+export default function App() {
   const { register, control, handleSubmit } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {

--- a/src/components/codeExamples/v6/clearError.ts
+++ b/src/components/codeExamples/v6/clearError.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, errors, handleSubmit, clearErrors } = useForm();
 
   const onSubmit = data => console.log(data);

--- a/src/components/codeExamples/v6/clearErrorTs.ts
+++ b/src/components/codeExamples/v6/clearErrorTs.ts
@@ -9,7 +9,7 @@ type FormInputs = {
   username: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, errors, handleSubmit, clearErrors } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {

--- a/src/components/codeExamples/v6/connectForm.ts
+++ b/src/components/codeExamples/v6/connectForm.ts
@@ -12,7 +12,7 @@ export const DeepNest = () => (
   </ConnectForm>
 );
 
-export const App = () => {
+export export default function App() {
   const methods = useForm();
   
   return (

--- a/src/components/codeExamples/v6/errorsMessage.ts
+++ b/src/components/codeExamples/v6/errorsMessage.ts
@@ -4,7 +4,7 @@ import { ErrorMessage } from '@hookform/error-message';
 
 export default function App() {
   const { register, errors, handleSubmit } = useForm({
-    criteriaMode "all"
+    criteriaMode: "all"
   });
   const onSubmit = data => console.log(data);
 

--- a/src/components/codeExamples/v6/errorsMessageTs.ts
+++ b/src/components/codeExamples/v6/errorsMessageTs.ts
@@ -8,7 +8,7 @@ interface FormInputs {
 
 export default function App() {
   const { register, errors, handleSubmit } = useForm<FormInputs>({
-    criteriaMode "all"
+    criteriaMode: "all"
   });
   const onSubmit = (data: FormInputs) => console.log(data);
 

--- a/src/components/codeExamples/v6/getStarted.ts
+++ b/src/components/codeExamples/v6/getStarted.ts
@@ -149,7 +149,7 @@ interface IFormValues {
   Age: number;
 }
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<IFormValues>();
 
   const onSubmit = (data: IFormValues) => {
@@ -228,7 +228,7 @@ import Select from "react-select";
 import { useForm, Controller } from "react-hook-form";
 import Input from "@material-ui/core/Input";
 
-const App = () => {
+export default function App() {
   const { control, handleSubmit } = useForm();
 
   const onSubmit = (data: IFormInput) => {
@@ -270,7 +270,7 @@ interface IFormInput {
   iceCreamType: string;
 }
 
-const App = () => {
+export default function App() {
   const { control, handleSubmit } = useForm<IFormInput>();
 
   const onSubmit = (data: IFormInput) => {

--- a/src/components/codeExamples/v6/joiResolver.tsx
+++ b/src/components/codeExamples/v6/joiResolver.tsx
@@ -8,7 +8,7 @@ const schema = Joi.object({
   age: Joi.string().required(),
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: joiResolver(schema),
   });

--- a/src/components/codeExamples/v6/joiResolverTs.ts
+++ b/src/components/codeExamples/v6/joiResolverTs.ts
@@ -13,7 +13,7 @@ const schema = Joi.object({
   age: Joi.number().required()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, errors } = useForm<IFormInput>({
     resolver: joiResolver(schema)
   });

--- a/src/components/codeExamples/v6/setAllErrors.ts
+++ b/src/components/codeExamples/v6/setAllErrors.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm({
     criteriaMode: 'all',
   });

--- a/src/components/codeExamples/v6/setAllErrorsTs.ts
+++ b/src/components/codeExamples/v6/setAllErrorsTs.ts
@@ -5,7 +5,7 @@ type FormInputs = {
   lastName: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm<FormInputs>({
     criteriaMode: 'all',
   });

--- a/src/components/codeExamples/v6/setError.ts
+++ b/src/components/codeExamples/v6/setError.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm();
   const onSubmit = data => {
     console.log(data)

--- a/src/components/codeExamples/v6/setErrorTs.ts
+++ b/src/components/codeExamples/v6/setErrorTs.ts
@@ -5,7 +5,7 @@ type FormInputs = {
   username: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm<FormInputs>();
   const onSubmit = (data: FormInputs) => {
     console.log(data)

--- a/src/components/codeExamples/v6/setMultipleErrors.ts
+++ b/src/components/codeExamples/v6/setMultipleErrors.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm();
 
   const onSubmit = data => {

--- a/src/components/codeExamples/v6/setMultipleErrorsTs.ts
+++ b/src/components/codeExamples/v6/setMultipleErrorsTs.ts
@@ -6,7 +6,7 @@ type FormInputs = {
   firstName: string;
 };
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setError, errors } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => {

--- a/src/components/codeExamples/v6/setValue.ts
+++ b/src/components/codeExamples/v6/setValue.ts
@@ -1,7 +1,7 @@
 export default `import * as React from "react";
 import { useForm } from "react-hook-form";
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setValue } = useForm();
 
   const onSubmit = data => {

--- a/src/components/codeExamples/v6/setValueTs.tsx
+++ b/src/components/codeExamples/v6/setValueTs.tsx
@@ -6,7 +6,7 @@ type FormInputs = {
   lastName: string
 }
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, setValue } = useForm<FormInputs>();
 
   const onSubmit = (data: FormInputs) => console.log(data);

--- a/src/components/codeExamples/v6/superStructResolver.tsx
+++ b/src/components/codeExamples/v6/superStructResolver.tsx
@@ -8,7 +8,7 @@ const schema = struct({
   age: 'number',
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: superstructResolver(schema),
   });

--- a/src/components/codeExamples/v6/validationResolver.ts
+++ b/src/components/codeExamples/v6/validationResolver.ts
@@ -10,7 +10,7 @@ const validationSchema = Joi.object({
     .required()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, errors } = useForm({
     resolver: async data => {
       const { error, value: values } = validationSchema.validate(data, {

--- a/src/components/codeExamples/v6/validationResolverTs.tsx
+++ b/src/components/codeExamples/v6/validationResolverTs.tsx
@@ -14,7 +14,7 @@ const validationSchema = Joi.object({
     .required()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, errors } = useForm<IFormInputs>({
     resolver: async data => {
       const { error, value: values } = validationSchema.validate(data, {

--- a/src/components/codeExamples/v6/validationSchema.ts
+++ b/src/components/codeExamples/v6/validationSchema.ts
@@ -8,7 +8,7 @@ const schema = yup.object().shape({
   age: yup.number().required(),
 }).required();
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: yupResolver(schema),
   });

--- a/src/components/codeExamples/v6/validationSchemaTs.ts
+++ b/src/components/codeExamples/v6/validationSchemaTs.ts
@@ -13,7 +13,7 @@ const schema = yup.object().shape({
   age: yup.number().required(),
 }).required();
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<Inputs>({
     resolver: yupResolver(schema), // yup, joi and even your own.
   });

--- a/src/components/codeExamples/v6/vestResolver.tsx
+++ b/src/components/codeExamples/v6/vestResolver.tsx
@@ -29,7 +29,7 @@ const validationSuite = vest.create((data = {}) => {
   });
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, errors } = useForm({
     resolver: vestResolver(validationSuite),
   });

--- a/src/components/codeExamples/v6/zodResolver.ts
+++ b/src/components/codeExamples/v6/zodResolver.ts
@@ -8,7 +8,7 @@ const schema = z.object({
   age: z.number()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: zodResolver(schema)
   });

--- a/src/components/codeExamples/v6/zodResolverTs.ts
+++ b/src/components/codeExamples/v6/zodResolverTs.ts
@@ -10,7 +10,7 @@ const schema = z.object({
 
 type Schema = z.infer<typeof schema>;
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<Schema>({
     resolver: zodResolver(schema)
   });

--- a/src/components/codeExamples/validationResolver.ts
+++ b/src/components/codeExamples/validationResolver.ts
@@ -10,7 +10,7 @@ const validationSchema = Joi.object({
     .required()
 });
 
-const App = () => {
+export default function App() {
   const {
     register,
     handleSubmit,

--- a/src/components/codeExamples/validationResolverTs.tsx
+++ b/src/components/codeExamples/validationResolverTs.tsx
@@ -14,7 +14,7 @@ const validationSchema = Joi.object({
     .required()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit, formState: { errors } } = useForm<IFormInputs>({
     resolver: async data => {
       const { error, value: values } = validationSchema.validate(data, {

--- a/src/components/codeExamples/validationSchema.ts
+++ b/src/components/codeExamples/validationSchema.ts
@@ -8,7 +8,7 @@ const schema = yup.object().shape({
   age: yup.number().required(),
 }).required();
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: yupResolver(schema),
   });

--- a/src/components/codeExamples/validationSchemaTs.ts
+++ b/src/components/codeExamples/validationSchemaTs.ts
@@ -13,7 +13,7 @@ const schema = yup.object().shape({
   age: yup.number().required(),
 }).required();
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<Inputs>({
     resolver: yupResolver(schema), // yup, joi and even your own.
   });

--- a/src/components/codeExamples/vestResolver.tsx
+++ b/src/components/codeExamples/vestResolver.tsx
@@ -29,7 +29,7 @@ const validationSuite = vest.create((data = {}) => {
   });
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: vestResolver(validationSuite),
   });

--- a/src/components/codeExamples/virtualizedList.ts
+++ b/src/components/codeExamples/virtualizedList.ts
@@ -16,7 +16,7 @@ const WindowedRow = React.memo(({ index, style, data }) => {
   return <input {...register(\`\${index}.quantity\`)} />
 })
 
-export const App = () => {
+export export default function App() {
   const onSubmit = (data) => console.log(data)
   const formMethods = useForm({ defaultValues: items })
 

--- a/src/components/codeExamples/watchCode.ts
+++ b/src/components/codeExamples/watchCode.ts
@@ -1,7 +1,7 @@
 export default `import React from "react";
 import { useForm } from "react-hook-form";
 
-function App() {
+export default function App() {
   const { register, watch, formState: { errors }, handleSubmit } = useForm();
   const watchShowAge = watch("showAge", false); // you can supply default value as second argument
   const watchAllFields = watch(); // when pass nothing as argument, you are watching everything

--- a/src/components/codeExamples/watchCodeTs.ts
+++ b/src/components/codeExamples/watchCodeTs.ts
@@ -7,7 +7,7 @@ interface IFormInputs {
   age: number
 }
 
-function App() {
+export default function App() {
   const { register, watch, formState: { errors }, handleSubmit } = useForm<IFormInputs>();
   const watchShowAge = watch("showAge", false); // you can supply default value as second argument
   const watchAllFields = watch(); // when pass nothing as argument, you are watching everything

--- a/src/components/codeExamples/watchFieldArrayCode.ts
+++ b/src/components/codeExamples/watchFieldArrayCode.ts
@@ -1,13 +1,16 @@
 export default `import * as React from "react";
 import { useForm, useFieldArray, ArrayField } from "react-hook-form";
 
-function App() {
+let renderCount = 0;
+
+export default function App() {
   const { register, control, handleSubmit, watch } = useForm();
   const { fields, remove, append } = useFieldArray({
     name: "test",
     control
   });
   const onSubmit = (data: FormValues) => console.log(data);
+  renderCount++;
   
   console.log(watch("test")); 
 

--- a/src/components/codeExamples/zodResolver.ts
+++ b/src/components/codeExamples/zodResolver.ts
@@ -8,7 +8,7 @@ const schema = z.object({
   age: z.number()
 });
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm({
     resolver: zodResolver(schema)
   });

--- a/src/components/codeExamples/zodResolverTs.ts
+++ b/src/components/codeExamples/zodResolverTs.ts
@@ -10,7 +10,7 @@ const schema = z.object({
 
 type Schema = z.infer<typeof schema>;
 
-const App = () => {
+export default function App() {
   const { register, handleSubmit } = useForm<Schema>({
     resolver: zodResolver(schema)
   });

--- a/src/components/useForm/ClearErrors.tsx
+++ b/src/components/useForm/ClearErrors.tsx
@@ -37,6 +37,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={clearError}
               url="https://codesandbox.io/s/react-hook-form-v7-clearerrors-w5tl6"
               tsRawData={clearErrorTs}

--- a/src/components/useForm/Control.tsx
+++ b/src/components/useForm/Control.tsx
@@ -35,6 +35,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={control}
               url="https://codesandbox.io/s/react-hook-form-v7-controller-5h1q5"
               tsRawData={controlTs}

--- a/src/components/useForm/FormState.tsx
+++ b/src/components/useForm/FormState.tsx
@@ -30,6 +30,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={formState}
               url="https://codesandbox.io/s/react-hook-form-v6-formstate-forked-tyqlp"
               tsRawData={formStateTs}

--- a/src/components/useForm/GetFieldState.tsx
+++ b/src/components/useForm/GetFieldState.tsx
@@ -211,6 +211,7 @@ getFieldState('test', formState); // ✅ register input and return field state
             </h2>
 
             <CodeArea
+              canEdit
               rawData={getFieldState}
               url={"https://codesandbox.io/s/getfieldstate-jvekk"}
             />

--- a/src/components/useForm/GetValues.tsx
+++ b/src/components/useForm/GetValues.tsx
@@ -39,6 +39,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={getValues}
               url="https://codesandbox.io/s/react-hook-form-v7-getvalues-2eioh"
               tsRawData={getValuesTs}

--- a/src/components/useForm/HandleSubmit.tsx
+++ b/src/components/useForm/HandleSubmit.tsx
@@ -41,12 +41,14 @@ export default ({ currentLanguage }) => {
 
             <TabGroup buttonLabels={["sync", "async"]}>
               <CodeArea
+                canEdit
                 rawData={handleSubmitCode}
                 tsRawData={handleSubmitCodeTs}
                 url="https://codesandbox.io/s/react-hook-form-handlesubmit-v7-uqmiy"
                 tsUrl="https://codesandbox.io/s/react-hook-form-handlesubmit-ts-v7-lcrtu"
               />
               <CodeArea
+                canEdit
                 rawData={handleSubmitAsyncCode}
                 url="https://codesandbox.io/s/react-hook-form-async-submit-validation-kpx0o"
               />

--- a/src/components/useForm/SetError.tsx
+++ b/src/components/useForm/SetError.tsx
@@ -50,18 +50,21 @@ export default ({ currentLanguage }) => {
               ]}
             >
               <CodeArea
+                canEdit
                 rawData={setError}
                 tsRawData={setErrorTs}
                 url="https://codesandbox.io/s/react-hook-form-v7-seterror-btbf8"
                 tsUrl="https://codesandbox.io/s/react-hook-form-v7-ts-seterror-nfxxu"
               />
               <CodeArea
+                canEdit
                 rawData={setMultipleErrors}
                 tsRawData={setMultipleErrorsTs}
                 url="https://codesandbox.io/s/react-hook-form-v7-seterror-3y1op"
                 tsUrl="https://codesandbox.io/s/react-hook-form-v7-ts-seterror-8h440"
               />
               <CodeArea
+                canEdit
                 rawData={setAllErrors}
                 tsRawData={setAllErrorsTs}
                 url="https://codesandbox.io/s/react-hook-form-set-single-field-with-multiple-errors-ogf20"

--- a/src/components/useForm/SetFocus.tsx
+++ b/src/components/useForm/SetFocus.tsx
@@ -38,6 +38,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={setFocus}
               tsRawData={setFocusTs}
               url="https://codesandbox.io/s/setfocus-rolus"

--- a/src/components/useForm/SetValue.tsx
+++ b/src/components/useForm/SetValue.tsx
@@ -42,6 +42,7 @@ export default ({ currentLanguage }) => {
 
             <TabGroup buttonLabels={["basic", "dependant fields"]}>
               <CodeArea
+                canEdit
                 rawData={setValue}
                 url="https://codesandbox.io/s/react-hook-form-v7-setvalue-h8wbk"
                 tsRawData={setValueTs}
@@ -49,6 +50,7 @@ export default ({ currentLanguage }) => {
                 tsUrl="https://codesandbox.io/s/react-hook-form-v7-ts-setvalue-8z9hx"
               />
               <CodeArea
+                canEdit
                 rawData={dependantFields}
                 url="https://codesandbox.io/s/dependant-field-dwin1"
               />

--- a/src/components/useForm/Trigger.tsx
+++ b/src/components/useForm/Trigger.tsx
@@ -50,6 +50,7 @@ export default ({ currentLanguage }) => {
             </h2>
 
             <CodeArea
+              canEdit
               rawData={trigger}
               url="https://codesandbox.io/s/react-hook-form-v6-triggervalidation-forked-8w9tn"
               tsRawData={triggerTs}

--- a/src/components/useForm/UnRegister.tsx
+++ b/src/components/useForm/UnRegister.tsx
@@ -235,6 +235,7 @@ const onClick = () => {
             </h2>
 
             <CodeArea
+              canEdit
               url="https://codesandbox.io/s/react-hook-form-unregister-v6-forked-qs8o6"
               rawData={unregisterCode}
               tsUrl="https://codesandbox.io/s/react-hook-form-unregister-v6-ts-forked-4k2ey"

--- a/src/components/useForm/resetField.tsx
+++ b/src/components/useForm/resetField.tsx
@@ -183,10 +183,12 @@ resetField('non-existent-name'); // ❌ failed by input not found
               buttonLabels={["Reset Field State", "Reset With Options"]}
             >
               <CodeArea
+                canEdit
                 rawData={resetFieldCode}
                 url="https://codesandbox.io/s/priceless-firefly-d0kuv"
               />
               <CodeArea
+                canEdit
                 rawData={resetFieldOptionCode}
                 url="https://codesandbox.io/s/resetfield-with-options-iw4wd"
               />

--- a/src/data/ts.tsx
+++ b/src/data/ts.tsx
@@ -96,6 +96,7 @@ errors?.key4?.message // no type error`}
     title: "Resolver",
     description: (
       <CodeArea
+        canEdit
         url={"https://codesandbox.io/s/react-hook-form-resolver-forked-mjsx7"}
         rawData={`import React from 'react';
 import { useForm, Resolver } from 'react-hook-form';
@@ -142,6 +143,7 @@ export default function App() {
     title: "SubmitHandler",
     description: (
       <CodeArea
+        canEdit
         rawData={handleSubmitCodeTs}
         url="https://codesandbox.io/s/react-hook-form-handlesubmit-ts-v7-z9z0g"
       />
@@ -151,6 +153,7 @@ export default function App() {
     title: "Control",
     description: (
       <CodeArea
+        canEdit
         url="https://codesandbox.io/s/control-2mg07"
         rawData={`import React from "react";
 import { useForm, useWatch, Control } from "react-hook-form";
@@ -192,6 +195,7 @@ export default function App() {
     title: "UseFormReturn",
     description: (
       <CodeArea
+        canEdit
         url={
           "https://codesandbox.io/s/react-hook-form-UseFormReturn-forked-yl40u"
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1611,6 +1611,11 @@
     lodash "^4.17.15"
     react-simple-animate "^3.3.8"
 
+"@hookform/error-message@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@hookform/error-message/-/error-message-2.0.0.tgz#9b1b037fd816ea9b1531c06aa7fab5f5154aa740"
+  integrity sha512-Y90nHzjgL2MP7GFy75kscdvxrCTjtyxGmOLLxX14nd08OXRIh9lMH/y9Kpdo0p1IPowJBiZMHyueg7p+yrqynQ==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -2835,6 +2840,11 @@ any-base@^1.1.0:
   resolved "https://registry.yarnpkg.com/any-base/-/any-base-1.1.0.tgz#ae101a62bc08a597b4c9ab5b7089d456630549fe"
   integrity sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg==
 
+any-promise@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+
 anymatch@~3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.2.tgz#c0557c096af32f106198f4f4e2a383537e378716"
@@ -3998,6 +4008,11 @@ commander@^2.20.0, commander@^2.20.3, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+commander@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
 commander@^6.2.0:
   version "6.2.1"
@@ -6927,6 +6942,18 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
+glob@7.1.6:
+  version "7.1.6"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
+  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.6, glob@^7.1.7:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
@@ -9630,6 +9657,15 @@ mute-stream@0.0.8, mute-stream@~0.0.4:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
+mz@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
+
 nanoid@^3.1.23:
   version "3.1.30"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
@@ -10519,6 +10555,11 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
 
+pirates@^4.0.1:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.5.tgz#feec352ea5c3268fb23a37c702ab1699f35a5f3b"
+  integrity sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==
+
 pixelmatch@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pixelmatch/-/pixelmatch-4.0.2.tgz#8f47dcec5011b477b67db03c243bc1f3085e8854"
@@ -11269,6 +11310,11 @@ react-helmet@6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
+"react-hook-form-v7@npm:react-hook-form@7":
+  version "7.28.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.28.1.tgz#95fc37be6c6b9d57212eb7eca055fb36d079b3b7"
+  integrity sha512-mgwxvXuvt3FMY/mdnWbPc++Zf1U5xYzkhOaL05mtFMLvXc9MvUhMUlKtUVuO12sOrgT3nPXBgVFawtiJ4ONrgg==
+
 react-hook-form@6.0.0-rc.1:
   version "6.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.0.0-rc.1.tgz#99a6876476c94493a61aba224d5106692859b7b7"
@@ -11289,6 +11335,13 @@ react-refresh@^0.9.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.9.0.tgz#71863337adc3e5c2f8a6bfddd12ae3bfe32aafbf"
   integrity sha512-Gvzk7OZpiqKSkxsQvO/mbTN1poglhmAV7gR/DdIrRrSMXraRQQlfikRJOr3Nb9GTMPC5kof948Zy6jJZIFtDvQ==
 
+react-runner@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/react-runner/-/react-runner-1.0.0.tgz#297a4e0e6a784c1befc874cd88e3e9b3d5d40444"
+  integrity sha512-rkcWe7MZpUxsqQ6m7NzwPi99hd/CQYXgw/VEdyUDyuhdaLoskVg02tbG6+DDrIvL5HquVIJjnxlARM0fE+3Oyg==
+  dependencies:
+    sucrase "^3.10.1"
+
 react-side-effect@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.1.tgz#66c5701c3e7560ab4822a4ee2742dee215d72eb3"
@@ -11298,6 +11351,11 @@ react-simple-animate@^3.3.12, react-simple-animate@^3.3.8:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/react-simple-animate/-/react-simple-animate-3.3.12.tgz#ddea0f230feb3c1f069fbdb0a26e735e0b233265"
   integrity sha512-lFXjxD6ficcpOMsHfcDs1jqdkCve6jNlJnubOCzVOLswFDRANsaLN4KwpezDuliEFz8Q1zyj4J7Tmj3KMRnPcg==
+
+react-simple-code-editor@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.11.0.tgz#bb57c7c29b570f2ab229872599eac184f5bc673c"
+  integrity sha512-xGfX7wAzspl113ocfKQAR8lWPhavGWHL3xSzNLeseDRHysT+jzRBi/ExdUqevSMos+7ZtdfeuBOXtgk9HTwsrw==
 
 react-simple-img@2.3.9:
   version "2.3.9"
@@ -12633,6 +12691,18 @@ subscriptions-transport-ws@^0.9.18:
     symbol-observable "^1.0.4"
     ws "^5.2.0 || ^6.0.0 || ^7.0.0"
 
+sucrase@^3.10.1:
+  version "3.20.3"
+  resolved "https://registry.yarnpkg.com/sucrase/-/sucrase-3.20.3.tgz#424f1e75b77f955724b06060f1ae708f5f0935cf"
+  integrity sha512-azqwq0/Bs6RzLAdb4dXxsCgMtAaD2hzmUr4UhSfsxO46JFPAwMnnb441B/qsudZiS6Ylea3JXZe3Q497lsgXzQ==
+  dependencies:
+    commander "^4.0.0"
+    glob "7.1.6"
+    lines-and-columns "^1.1.6"
+    mz "^2.7.0"
+    pirates "^4.0.1"
+    ts-interface-checker "^0.1.9"
+
 sudo-prompt@^8.2.0:
   version "8.2.5"
   resolved "https://registry.yarnpkg.com/sudo-prompt/-/sudo-prompt-8.2.5.tgz#cc5ef3769a134bb94b24a631cc09628d4d53603e"
@@ -12812,6 +12882,20 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
+thenify-all@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.1.tgz#8932e686a4066038a016dd9e2ca46add9838a95f"
+  integrity sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==
+  dependencies:
+    any-promise "^1.0.0"
+
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -12965,6 +13049,11 @@ trough@^1.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/true-case-path/-/true-case-path-2.2.1.tgz#c5bf04a5bbec3fd118be4084461b3a27c4d796bf"
   integrity sha512-0z3j8R7MCjy10kc/g+qg7Ln3alJTodw9aDuVWZa3uiWqfuBMKeAeP2ocWcxoyM3D73yz3Jt/Pu4qPr4wHSdB/Q==
+
+ts-interface-checker@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
+  integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
 ts-node@^9:
   version "9.1.1"


### PR DESCRIPTION
react-hook-form is a great library and I use it a lot, it would be nice to play with it while reading the doc instead of be navigated to another website, this PR is a POC for that, using [react-runner](https://github.com/nihgwu/react-runner)

[Preview](https://react-hook-form-website-git-fork-nihgwu-neo-9c4abb-bluebill1049.vercel.app/get-started)

TODO:

- [x] Configurable live editing
- [ ] Lazy loading of external packages like `react-select` `react-redux`
- [ ] Work with previous versions of react-hook-form