### PR TITLE
Enhancement: fix of button togglegroup alignment in lightmode

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -85,7 +85,7 @@
 }
 
 .toggleGroup > button:last-child {
-  border-left: 0;
+  border-left: 0 !important;
   border-top-right-radius: 4px;
   border-bottom-right-radius: 4px;
 }


### PR DESCRIPTION
closes #748 

## Screenshot of issue

![alignment-issue](https://user-images.githubusercontent.com/42692074/160835168-4564d747-412b-4f5d-8650-9ddf30e1aacd.png) 






Button width change in light mode is causing the word "React Native" to break. 

Because of the "React Native" button being a border box element, changing border from `0` to `1px` affecting its width. Increasing width of button will also fix it but I thought of finding out css rule causing the issue. 


#### CSS Rule applied for border in dark mode

```css
.toggleGroup > button:last-child {
  border-left: 0;
  .
  .
  .
}

```
#### CSS Rule applied for border in light mode:

```css
.light button {
  border: 1px solid transparent !important;
  .
  .
  .
}
```

#### Fix Added

```css
.toggleGroup > button:last-child {
  border-left: 0 !important;
  .
  .
  .
}

```

The fix is about same rule  being applied in both light and dark mode.