### PR TITLE
fix optional field generate incorrect code 🐛

### DIFF
--- a/src/components/logic/generateCode.ts
+++ b/src/components/logic/generateCode.ts
@@ -44,7 +44,7 @@ ${
           })
           const ref = isV7
             ? `{...register${
-                required ? `("${name}", { required: true })` : ""
+                required ? `("${name}", { required: true })` : `("${name}")`
               }}`
             : ` ref={register${required ? "({ required: true })" : ""}}`
 


### PR DESCRIPTION
- Fix #762. I hope someone else doesn't get confused when they use the Bulder playground.
- Before this PR:
![Before](https://user-images.githubusercontent.com/8603085/162566222-b47bd8fd-1f9c-429c-9742-1a02ae6c6658.png)
- After: this PR
![After](https://user-images.githubusercontent.com/8603085/162566229-9661c955-3e2a-4ae2-8bdc-73a3b42682b6.png)

