### PR TITLE
fix (docs): add missing closing parentheses for joi & zod code snippets

### DIFF
--- a/src/components/codeExamples/joiResolver.tsx
+++ b/src/components/codeExamples/joiResolver.tsx
@@ -14,7 +14,7 @@ const App = () => {
   });
 
   return (
-    <form onSubmit={handleSubmit(d => console.log(d)}>
+    <form onSubmit={handleSubmit(d => console.log(d))}>
       <input {...register("name")} />
       <input type="number" {...register("age")} />
       <input type="submit" />

--- a/src/components/codeExamples/v6/joiResolver.tsx
+++ b/src/components/codeExamples/v6/joiResolver.tsx
@@ -14,7 +14,7 @@ const App = () => {
   });
 
   return (
-    <form onSubmit={handleSubmit(d => console.log(d)}>
+    <form onSubmit={handleSubmit(d => console.log(d))}>
       <input name="name" ref={register} />
       <input name="age" type="number" ref={register} />
       <input type="submit" />

--- a/src/components/codeExamples/v6/zodResolver.ts
+++ b/src/components/codeExamples/v6/zodResolver.ts
@@ -14,7 +14,7 @@ const App = () => {
   });
 
   return (
-    <form onSubmit={handleSubmit(d => console.log(d)}>
+    <form onSubmit={handleSubmit(d => console.log(d))}>
       <input name="name" ref={register} />
       <input name="age" type="number" ref={register} />
       <input type="submit" />

--- a/src/components/codeExamples/zodResolver.ts
+++ b/src/components/codeExamples/zodResolver.ts
@@ -14,7 +14,7 @@ const App = () => {
   });
 
   return (
-    <form onSubmit={handleSubmit(d => console.log(d)}>
+    <form onSubmit={handleSubmit(d => console.log(d))}>
       <input {...register("name")} />
       <input {...register("age")} type="number" />
       <input type="submit" />


### PR DESCRIPTION
### Description

I noticed that there were a couple of code snippets in the docs that were missing the closing `)` in the `onSubmit` handler. So I've gone ahead and made a quick PR to fix them.