### PR TITLE
Fix:  typo in `setValue` link on `useController` page

### DIFF
--- a/src/components/UseControllerMethods.tsx
+++ b/src/components/UseControllerMethods.tsx
@@ -57,7 +57,7 @@ export default ({ currentLanguage, isController }) => {
                     </Link>{" "}
                     and you should avoid manually invoke{" "}
                     <Link
-                      to="/api/useform/setValue"
+                      to="/api/useform/setvalue"
                       aria-label={"read more about setValue"}
                     >
                       setValue


### PR DESCRIPTION
Tiny PR to fix broken link on `useController` page