### PR TITLE
useForm API: Improve correctness of JS terminology

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -23,9 +23,9 @@ export default {
     ),
     description: (
       <p>
-        <code>useForm</code> is custom hook for managing forms with ease. It
-        takes <b>optional</b> arguments. The following example demonstrates all
-        of the arguments along with their default values.
+        <code>useForm</code> is a custom hook for managing forms with ease. It
+        takes one object as <b>optional</b> argument. The following example demonstrates all
+        of its properties along with their default values.
       </p>
     ),
     validateCriteriaMode: (


### PR DESCRIPTION
I think that `useForm()` accepts only **one** optional argument and the things listed in the example are **its properties**.