### PR TITLE
fix: code snippet style on light mode

### DIFF
--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -77,6 +77,7 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
     language && language.currentLanguage
       ? language
       : { currentLanguage: defaultLang }
+  const lightMode = setting?.lightMode
   const isV7 = setting?.version === 7
 
   const links = [
@@ -440,7 +441,11 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
 
           {getStarted.schema.step1}
 
-          <span className={getStartedStyles.installCode}>
+          <span
+            className={`${getStartedStyles.installCode} ${
+              lightMode ? getStartedStyles.lightInstallCode : ""
+            }`}
+          >
             npm install @hookform/resolvers yup
             <button
               className={getStartedStyles.copyButton}


### PR DESCRIPTION
This PR applied the following style fix in the [Schema Validation](https://react-hook-form.com/get-started#SchemaValidation) section:

Before:
![image](https://user-images.githubusercontent.com/62269974/180652898-d8690470-dc84-4b4b-8af1-a71ae5b000b8.png)
After:
![image](https://user-images.githubusercontent.com/62269974/180652918-53217b81-1645-4865-a0f2-6e123749c0e6.png)
