### PR TITLE
fix: uppercase "Input" instead of "input"

### DIFF
--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -350,8 +350,8 @@ export default function App(props) {
   
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <Input {...register("firstName")} defaultValue={props.firstName} />
-      <Input {...register("lastName")} defaultValue={props.lastName} />
+      <input {...register("firstName")} defaultValue={props.firstName} />
+      <input {...register("lastName")} defaultValue={props.lastName} />
       <input type="submit" />
     </form>
   );


### PR DESCRIPTION
I guess the code example in section "Integrating with global state" was supposed to use "input" (all lowercase) instead of "Input" component. Because there is no "Input" component being defined. 