### PR TITLE
remove `defaultValues` from `useFieldArray` docs

### DIFF
--- a/src/components/codeExamples/useFieldArrayPreview.ts
+++ b/src/components/codeExamples/useFieldArrayPreview.ts
@@ -5,10 +5,7 @@ export default function App() {
   const { control, handleSubmit } = useForm();
   const { fields, append, update } = useFieldArray({
     control,
-    name: 'array',
-    defaultValues: {
-      'array': []
-    }
+    name: 'array'
   });
 
   return (


### PR DESCRIPTION
Looks like it's not actually supported