### PR TITLE
Rules text turns black in light mode. fix #811 

### DIFF
--- a/src/styles/typography.module.css
+++ b/src/styles/typography.module.css
@@ -54,7 +54,7 @@ h3.subTitle:before {
 }
 
 .rulesTitle {
-  color: white;
+  color: currentColor;
   line-height: 1;
   margin-top: 2rem;
   border: 1px solid var(--color-secondary);


### PR DESCRIPTION
fix #811
![screenshot 2022-08-31 19 53 05](https://user-images.githubusercontent.com/44772513/187662633-42c979a8-542a-4203-bd3e-8b3b5a0cc1a6.png)

The word Rules is now black in light mode, as shown in the image