### PR TITLE
Fix typo on useWatch and Get Started pages

### DIFF
--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -128,7 +128,7 @@ export default function UseFieldArray({
         </li>
         <li>
           <p>
-            The only different between <code>useWatch</code> and{" "}
+            The only difference between <code>useWatch</code> and{" "}
             <code>watch</code> is at the root (
             <Link to={"/api/useform"}>
               <code>useForm</code>
@@ -138,7 +138,7 @@ export default function UseFieldArray({
         </li>
         <li>
           <p>
-            <code>useWatch</code> execution order matters, which means if you
+            <code>useWatch</code>'s execution order matters, which means if you
             update a form value before the subscription is in place, then the
             value updated will be ignored.
           </p>
@@ -154,7 +154,7 @@ setValue('example', 'data');
         </li>
         <li>
           <p>
-            <code>useWatch</code> result is optimised for render phase instead
+            <code>useWatch</code>'s result is optimised for render phase instead
             of <code>useEffect</code>'s deps, to detect value updates you may
             want to use an external custom hook for value comparison.
           </p>

--- a/src/data/en/getStarted.tsx
+++ b/src/data/en/getStarted.tsx
@@ -246,7 +246,7 @@ export default {
     description: (
       <p>
         React Hook Form provides an <code>errors</code> object to show you the
-        errors in the form. <code>errors</code>'s type will return given
+        errors in the form. <code>errors</code>' type will return given
         validation constraints. The following example showcases a required
         validation rule.
       </p>


### PR DESCRIPTION
Fixed typos.

### Before:

<img width="913" alt="Screenshot 2022-09-17 at 11 51 51 PM" src="https://user-images.githubusercontent.com/51022010/190872522-7b3c4f4e-50b7-450c-89b4-907f3f8a863c.png">

<img width="922" alt="Screenshot 2022-09-17 at 11 47 29 PM" src="https://user-images.githubusercontent.com/51022010/190872526-ebd81cf3-b81a-4b5e-a352-b67c2b1f722f.png">


### After:
<img width="903" alt="Screenshot 2022-09-17 at 11 47 04 PM" src="https://user-images.githubusercontent.com/51022010/190872539-53f690b9-667f-4fc9-8e6e-d1e0cb362392.png">

<img width="936" alt="Screenshot 2022-09-17 at 11 48 49 PM" src="https://user-images.githubusercontent.com/51022010/190872551-6ff9d759-958f-42f2-af78-3a8d53932b75.png">

