### PR TITLE
Fix light mode navbar font

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -219,7 +219,6 @@
 
   .darkActionButtonGroup a {
     color: white;
-    font-weight: 400;
   }
 
   .tools {

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -219,7 +219,7 @@
 
   .darkActionButtonGroup a {
     color: white;
-    font-weight: 500;
+    font-weight: 400;
   }
 
   .tools {


### PR DESCRIPTION
### Fixes #782 

### Before:

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/51022010/190913466-65d8d6f6-eccf-49ef-b70c-470112e52d11.gif)

### After:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/51022010/190913480-559282ce-bc9b-4259-8a00-31c078b05047.gif)
