### PR TITLE
fix: add `getFieldState` types

### DIFF
--- a/src/components/useForm/GetFieldState.tsx
+++ b/src/components/useForm/GetFieldState.tsx
@@ -26,7 +26,9 @@ export const GetFieldState = () => {
             <code className={typographyStyles.codeHeading}>
               <h2>
                 getFieldState:{" "}
-                <span className={typographyStyles.typeText}>{`object`}</span>
+                <span
+                  className={typographyStyles.typeText}
+                >{`(name: string, formState?: Object) => ({isDirty, isTouched, invalid, error})`}</span>
               </h2>
             </code>
 


### PR DESCRIPTION
## Changes

Change `getFieldState` type from `object` to `(name: string, formState?: Object) => ({isDirty, isTouched, invalid, error})` to make API more clear.

### Preview
[getFieldState API](https://react-hook-form-website-git-fork-abdmmar-abdmm-ce6aed-hook-form.vercel.app/api/useform/getfieldstate/)
