### PR TITLE
include missing prop to forwardRef example

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -547,6 +547,7 @@ const App = () => {
 
 const firstName = register('firstName', { required: true })
 <TextInput
+  name={firstName.name}
   onChange={firstName.onChange}
   onBlur={firstName.onBlur}
   inputRef={firstName.ref} // you can achieve the same for different ref name such as innerRef


### PR DESCRIPTION
<img width="969" alt="image" src="https://user-images.githubusercontent.com/36615680/193393369-3e81d376-f586-4636-897c-5f6ebf774e35.png">

[Documentation link](https://react-hook-form.com/api/useform/register/#example:~:text=How%20to%20work%20with%20innerRef%2C%20inputRef%3F)

I added the name prop. 

I didn't add a name prop to my code like a document at the first time.
My code didn't validate well when the mode was `all`, `onChange`, and `onBulr`. 
I found the name prop was the cause. 

I think it would be better to add a name prop to the document.