### PR TITLE
docs: fix "become a contributor" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Thanks goes to all our backers! [[Become a backer](https://opencollective.com/re
 
 ## Contributors
 
-Thanks goes to these wonderful people. [[Become a contributor](https://github.com/react-hook-form/react-hook-form/blob/master/CONTRIBUTING.md)].
+Thanks goes to these wonderful people. [[Become a contributor](https://github.com/react-hook-form/documentation/blob/master/CONTRIBUTING.md)].
 
 <a href="https://github.com/react-hook-form/react-hook-form/graphs/contributors">
     <img src="https://opencollective.com/react-hook-form/contributors.svg?width=950" />


### PR DESCRIPTION
Change "Become a contributor" link from `react-hook-form/react-hook-form` repository to `react-hook-form/documentation` 
 repository