### PR TITLE
fix: edit links for api and advanced pages

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -22,6 +22,7 @@ const Layout = (props: {
   const { currentLanguage } =
     language && language.currentLanguage ? language : { currentLanguage: "en" }
   const lightMode = state?.setting?.lightMode
+  const currentVersion = state?.setting?.version
   const [show, setShow] = React.useState(false)
   const scrollHandler = () => {
     if (window.scrollY > 75) {
@@ -30,7 +31,11 @@ const Layout = (props: {
       setShow(false)
     }
   }
-  const editLink = getEditLink(currentLanguage, props.location?.pathname)
+  const editLink = getEditLink(
+    currentVersion,
+    currentLanguage,
+    props.location?.pathname
+  )
 
   React.useEffect(() => {
     window.addEventListener("scroll", scrollHandler)

--- a/src/components/logic/getEditLink.tsx
+++ b/src/components/logic/getEditLink.tsx
@@ -1,22 +1,31 @@
 const preFix =
-  "https://github.com/react-hook-form/documentation/edit/master/src/data/"
+  "https://github.com/react-hook-form/documentation/edit/v6-v5/src/data/"
 
 export const getEditLink = (
+  currentVersion: number,
   currentLanguage: string,
   pathname: string
 ): string => {
   if (!pathname) return ""
+
+  let versionTag = ""
+  if (currentVersion === 6) {
+    versionTag = "V6/"
+  } else if (currentVersion === 5) {
+    versionTag = "V5/"
+  }
 
   if (pathname === "/" || pathname === "") {
     return preFix + "home.tsx"
   } else if (pathname.includes("get-started")) {
     return `${preFix}${currentLanguage}/getStarted.tsx`
   } else if (pathname.includes("api")) {
-    return `${preFix}${currentLanguage}/api.tsx`
+    return `${preFix}${versionTag}${currentLanguage}/api.tsx`
   } else if (pathname.includes("ts")) {
     return `${preFix}ts.tsx`
   } else if (pathname.includes("advanced-usage")) {
-    return `${preFix}${currentLanguage}/advanced.tsx`
+    const tag = currentVersion < 7 && currentLanguage === "en" ? "V6/" : ""
+    return `${preFix}${tag}${currentLanguage}/advanced.tsx`
   } else if (pathname.includes("faqs")) {
     return `${preFix}${currentLanguage}/faq.tsx`
   } else if (pathname.includes("dev-tools")) {


### PR DESCRIPTION
Specifically targeted only data sources under V6 and V5 folders for legacy-docs.

Points to note:
1. Modified source prefix to point to `V6-V5` branch instead of `master` as legacy docs are served from that branch.
2. Noticed there are two versions of `/advanced-usage`. For now handled the links as they are shown in docs.
    - `V7, *` https://github.com/react-hook-form/documentation/blob/v6-v5/src/data/en/advanced.tsx
    - `V6, en` https://github.com/react-hook-form/documentation/blob/v6-v5/src/data/V6/en/advanced.tsx