### PR TITLE
FIX: Add missing reference to `remove` in the `useFieldArray` example

### DIFF
--- a/src/components/codeExamples/useFieldArray.ts
+++ b/src/components/codeExamples/useFieldArray.ts
@@ -5,7 +5,7 @@ function App() {
   const { register, control, handleSubmit, reset, trigger, setError } = useForm({
     // defaultValues: {}; you can populate the fields by this attribute 
   });
-  const { fields, append } = useFieldArray({
+  const { fields, append, remove } = useFieldArray({
     control,
     name: "test"
   });


### PR DESCRIPTION
The code example referenced in the [`useFieldArray` documentation page](https://react-hook-form.com/api/usefieldarray) is missing to define the `remove` that is referenced below (see screenshot).

<img width="957" alt="image" src="https://user-images.githubusercontent.com/1332450/195693147-9100542c-df00-49e2-ae19-174df243c662.png">
