### PR TITLE
#838 Apply storage type "window.localStorage" on little state machine

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,38 @@
+import * as React from "react"
 import withLittleStateMachine from "./with-little-state-machine"
+import { useStateMachine } from "little-state-machine"
 
 export const wrapRootElement = withLittleStateMachine
 
 export const onServiceWorkerUpdateReady = () => {
   window.location.reload()
+}
+
+const forceUpdate = (state, payload) => {
+  return {
+    ...state,
+    setting: {
+      ...state.setting,
+      ...payload,
+    },
+  }
+}
+
+export const wrapPageElement = ({ element }) => {
+  const { actions, state } = useStateMachine({ forceUpdate })
+  React.useEffect(() => {
+    const lightMode = !state?.setting?.lightMode
+    // NOTE: Global state on SSR and CSR cannot be synced when using
+    // storage type window.localStorage of little-state-machine.
+    // If light mode is applied on browser, SSR still renders dark mode when opening new tab,
+    // enable dark mode to sync with SSR HTML response then re-apply light mode after first rendering
+
+    actions.forceUpdate({ lightMode })
+    // Restore selected state of light mode
+    setTimeout(() => {
+      actions.forceUpdate({ lightMode: !lightMode })
+    }, 200)
+  }, [])
+
+  return <>{element}</>
 }

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -21,7 +21,12 @@ const forceUpdate = (state, payload) => {
 export const wrapPageElement = ({ element }) => {
   const { actions, state } = useStateMachine({ forceUpdate })
   React.useEffect(() => {
+    if (!lightMode) {
+      return
+    }
+
     const lightMode = !state?.setting?.lightMode
+
     // NOTE: Global state on SSR and CSR cannot be synced when using
     // storage type window.localStorage of little-state-machine.
     // If light mode is applied on browser, SSR still renders dark mode when opening new tab,

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -21,7 +21,7 @@ const forceUpdate = (state, payload) => {
 export const wrapPageElement = ({ element }) => {
   const { actions, state } = useStateMachine({ forceUpdate })
   React.useEffect(() => {
-    if (!lightMode) {
+    if (!state?.setting?.lightMode) {
       return
     }
 

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -25,7 +25,7 @@ export default function Toggle({ style }: { style?: React.CSSProperties }) {
         id="toggle"
         type="checkbox"
         onChange={onChange}
-        defaultChecked={lightMode}
+        checked={lightMode}
       />
       <span className={`${styles.slider} ${styles.round}`} />
     </label>

--- a/with-little-state-machine.js
+++ b/with-little-state-machine.js
@@ -3,11 +3,16 @@ import { createStore, StateMachineProvider } from "little-state-machine"
 import formData from "./src/state/formData"
 import setting from "./src/state/setting"
 
-createStore({
-  formData,
-  setting,
-})
-
-export default ({ element }) => (
-  <StateMachineProvider>{element}</StateMachineProvider>
+createStore(
+  {
+    formData,
+    setting,
+  },
+  {
+    storageType: typeof window !== "undefined" ? window.localStorage : {},
+  }
 )
+
+export default ({ element }) => {
+  return <StateMachineProvider>{element}</StateMachineProvider>
+}


### PR DESCRIPTION
Start using "window.localStorage" for little state machine in order to keep theme settings on multiple tabs.

Related issue: https://github.com/react-hook-form/documentation/issues/838