### PR TITLE
Update DevTools.tsx | Add -D flag to install cmd

### DIFF
--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -86,11 +86,11 @@ export default ({ defaultLang, content }: Props) => {
               lightMode ? getStartedStyle.lightInstallCode : ""
             }`}
           >
-            npm install @hookform/devtools
+            npm install -D @hookform/devtools
             <button
               className={getStartedStyle.copyButton}
               onClick={() => {
-                copyClipBoard("npm install @hookform/devtools")
+                copyClipBoard("npm install -D @hookform/devtools")
                 alert(generic.copied["en"])
               }}
             >


### PR DESCRIPTION
Added the `-D` flag to the installation command so users can streamline copy-pasting the command without needing to remember to add the flag when running the command.