### PR TITLE
fix(form-builder): updating edited input on an empty list results in a blank error page

### DIFF
--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -83,7 +83,7 @@ function BuilderPage({
   const onSubmit = (data) => {
     if (editIndex >= 0) {
       formData[editIndex] = data
-      updateFormData([...formData])
+      updateFormData([...formData.filter((formInput) => formInput)])
       setFormData(defaultValue)
       setEditIndex(-1)
     } else {


### PR DESCRIPTION
## Version Number
V7

## Preview

![image](https://user-images.githubusercontent.com/50788123/196048101-b206834e-2fb0-4d09-ac37-e7ee9b73f229.png)

## Steps to reproduce
- Go to [Form Builder](https://react-hook-form.com/form-builder) page with the default example field
- Click "Edit" button on one of the items (except the first item) in the list Layout section
- Click "Delete All" button at the bottom of the Layout section
- Click "Update" button in the Input Creator section
- Page is blank and unusable 

## Expected behaviour

When updating the form input item and the input list is empty, add the updated item to the list

## What browsers are you seeing the problem on?

- Google Chrome Version 106.0.5249.119
- Brave Version 1.44.112 Chromium: 106.0.5249.119

## Relevant log output

### Console
![image](https://user-images.githubusercontent.com/50788123/196048031-d546bfed-35f2-4d5b-b98d-7b47128bfe03.png)

### Local Storage
```
{
    formData: [
      null, // root cause
      {
        "name": "Last name",
        "type": "text",
        "toggle": true,
        "required": true,
        "max": "",
        "min": "",
        "maxLength": "100",
        "pattern": ""
      }
    ],
    setting: {
      "lightMode": false,
      "isFocusOnSearch": false
    }
}
```
