### PR TITLE
Proposal change to the copied code

### DIFF
--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -19,6 +19,7 @@ import * as containerStyles from "../styles/container.module.css"
 import * as typographyStyles from "../styles/typography.module.css"
 import * as styles from "./BuilderPage.module.css"
 import CodeArea from "./CodeArea"
+import ClipBoard from "./ClipBoard"
 
 const { useState, useRef, useEffect } = React
 
@@ -404,18 +405,14 @@ function BuilderPage({
             }}
           >
             <div className={styles.buttonWrapper}>
-              <button
+              <ClipBoard
+                onClick={() => copyClipBoard(generateCode(formData))}
                 className={`${styles.button} ${styles.copyButton}`}
-                onClick={() => {
-                  copyClipBoard(generateCode(formData))
-                  alert(generic.copied[currentLanguage])
-                }}
-                aria-label={generic.copied[currentLanguage]}
-              >
-                {generic.copy[currentLanguage]}
-              </button>
+                currentLanguage={currentLanguage}
+              />
             </div>
-            <CodeArea rawData={generateCode(formData)} />
+
+            <CodeArea rawData={generateCode(formData)} withOutCopy />
           </section>
         </section>
       </div>

--- a/src/components/ClipBoard.tsx
+++ b/src/components/ClipBoard.tsx
@@ -1,0 +1,39 @@
+import React, { useState } from "react"
+import generic from "../data/generic"
+
+const ClipBoard = ({
+  currentLanguage,
+  className,
+  onClick,
+}: {
+  onClick: () => void
+  className?: string
+  currentLanguage: string
+}) => {
+  const [copiedCode, setCopiedCode] = useState<boolean>(false)
+
+  React.useEffect(() => {
+    if (copiedCode) {
+      setTimeout(() => {
+        setCopiedCode(false)
+      }, 3000)
+    }
+  }, [copiedCode])
+
+  return (
+    <button
+      className={className}
+      onClick={() => {
+        onClick()
+        setCopiedCode(true)
+      }}
+      aria-label={generic.copied[currentLanguage]}
+    >
+      {copiedCode
+        ? generic.codeCopied[currentLanguage]
+        : generic.copy[currentLanguage]}
+    </button>
+  )
+}
+
+export default ClipBoard

--- a/src/components/CodeArea.module.css
+++ b/src/components/CodeArea.module.css
@@ -45,7 +45,6 @@
 }
 
 .active,
-.copiedCodeButton,
 .copyButton:hover {
   background: none;
   border: 1px solid var(--color-secondary);

--- a/src/components/CodeArea.module.css
+++ b/src/components/CodeArea.module.css
@@ -45,6 +45,7 @@
 }
 
 .active,
+.copiedCodeButton,
 .copyButton:hover {
   background: none;
   border: 1px solid var(--color-secondary);

--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import copyClipBoard from "./utils/copyClipBoard"
 import { useStateMachine } from "little-state-machine"
-import generic from "../data/generic"
 import { highlightAllUnder } from "prismjs"
+import ClipBoard from "./ClipBoard"
 import * as styles from "./CodeArea.module.css"
 
 export const CodeSandBoxLink = ({
@@ -75,7 +75,6 @@ export default function CodeArea({
   const {
     state: { language },
   } = useStateMachine()
-  const [copiedCode, setCopiedCode] = React.useState<boolean>(false)
   const [currentType, setType] = React.useState<
     typeof ToggleTypes[keyof typeof ToggleTypes]
   >(
@@ -107,14 +106,6 @@ export default function CodeArea({
     }
     highlight()
   }, [])
-
-  React.useEffect(() => {
-    if (copiedCode) {
-      setTimeout(() => {
-        setCopiedCode(false)
-      }, 3000)
-    }
-  }, [copiedCode])
 
   return (
     <section
@@ -154,20 +145,11 @@ export default function CodeArea({
           </button>
         )}
         {!withOutCopy && (
-          <button
-            className={`${styles.button} ${styles.copyButton} ${
-              copiedCode ? styles.copiedCodeButton : null
-            }`}
-            onClick={() => {
-              copyClipBoard(getData())
-              setCopiedCode(true)
-            }}
-            aria-label={generic.copied[currentLanguage]}
-          >
-            {copiedCode
-              ? generic.codeCopied[currentLanguage]
-              : generic.copy[currentLanguage]}
-          </button>
+          <ClipBoard
+            className={`${styles.button} ${styles.copyButton}`}
+            onClick={() => copyClipBoard(getData())}
+            currentLanguage={currentLanguage}
+          />
         )}
 
         {((url && currentType === ToggleTypes.js) ||

--- a/src/components/CodeArea.tsx
+++ b/src/components/CodeArea.tsx
@@ -75,6 +75,7 @@ export default function CodeArea({
   const {
     state: { language },
   } = useStateMachine()
+  const [copiedCode, setCopiedCode] = React.useState<boolean>(false)
   const [currentType, setType] = React.useState<
     typeof ToggleTypes[keyof typeof ToggleTypes]
   >(
@@ -106,6 +107,14 @@ export default function CodeArea({
     }
     highlight()
   }, [])
+
+  React.useEffect(() => {
+    if (copiedCode) {
+      setTimeout(() => {
+        setCopiedCode(false)
+      }, 3000)
+    }
+  }, [copiedCode])
 
   return (
     <section
@@ -146,14 +155,18 @@ export default function CodeArea({
         )}
         {!withOutCopy && (
           <button
-            className={`${styles.button} ${styles.copyButton}`}
+            className={`${styles.button} ${styles.copyButton} ${
+              copiedCode ? styles.copiedCodeButton : null
+            }`}
             onClick={() => {
               copyClipBoard(getData())
-              alert(generic.copied[currentLanguage])
+              setCopiedCode(true)
             }}
             aria-label={generic.copied[currentLanguage]}
           >
-            {generic.copy[currentLanguage]}
+            {copiedCode
+              ? generic.codeCopied[currentLanguage]
+              : generic.copy[currentLanguage]}
           </button>
         )}
 

--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -16,6 +16,7 @@ import * as containerStyles from "../styles/container.module.css"
 import * as buttonStyles from "../styles/button.module.css"
 import * as getStartedStyle from "./GetStarted.module.css"
 import * as styles from "./DevTools.module.css"
+import ClipBoard from "./ClipBoard"
 
 interface Props {
   defaultLang: string
@@ -87,18 +88,11 @@ export default ({ defaultLang, content }: Props) => {
             }`}
           >
             npm install -D @hookform/devtools
-            <button
+            <ClipBoard
               className={getStartedStyle.copyButton}
-              onClick={() => {
-                copyClipBoard("npm install -D @hookform/devtools")
-                alert(generic.copied["en"])
-              }}
-            >
-              <span>
-                <span />
-              </span>{" "}
-              {generic.copy["en"]}
-            </button>
+              currentLanguage="en"
+              onClick={() => copyClipBoard("npm install -D @hookform/devtools")}
+            />
           </span>
 
           <p>{content.step2}</p>

--- a/src/components/GetStarted.tsx
+++ b/src/components/GetStarted.tsx
@@ -6,6 +6,7 @@ import generic from "../data/generic"
 import copyClipBoard from "./utils/copyClipBoard"
 import { useStateMachine } from "little-state-machine"
 import * as styles from "./GetStarted.module.css"
+import ClipBoard from "./ClipBoard"
 
 export default function GetStarted({
   quickStartRef,
@@ -30,18 +31,11 @@ export default function GetStarted({
         }`}
       >
         npm install react-hook-form
-        <button
+        <ClipBoard
           className={styles.copyButton}
-          onClick={() => {
-            copyClipBoard("npm install react-hook-form")
-            alert(generic.copied[currentLanguage])
-          }}
-        >
-          <span>
-            <span />
-          </span>{" "}
-          {generic.copy[currentLanguage]}
-        </button>
+          currentLanguage={currentLanguage}
+          onClick={() => copyClipBoard("npm install react-hook-form")}
+        />
       </span>
 
       <h2

--- a/src/components/GetStartedPage.tsx
+++ b/src/components/GetStartedPage.tsx
@@ -34,6 +34,7 @@ import getStarted from "../data/en/getStarted"
 import TabGroup from "./TabGroup"
 import useController from "./codeExamples/useController"
 import useControllerTs from "./codeExamples/useControllerTs"
+import ClipBoard from "./ClipBoard"
 
 const { useRef, useEffect } = React
 const enLinks = [
@@ -359,15 +360,13 @@ const Faq = ({ location, defaultLang, getStarted }: Props) => {
             }`}
           >
             npm install @hookform/resolvers yup
-            <button
+            <ClipBoard
               className={getStartedStyles.copyButton}
-              onClick={() => {
+              onClick={() =>
                 copyClipBoard("npm install @hookform/resolvers yup")
-                alert("Code copied into your clipboard.")
-              }}
-            >
-              {generic.copy[currentLanguage]}
-            </button>
+              }
+              currentLanguage={currentLanguage}
+            />
           </span>
 
           {getStarted.schema.step2}

--- a/src/data/en/faq.tsx
+++ b/src/data/en/faq.tsx
@@ -10,6 +10,7 @@ import * as tableStyles from "../../styles/table.module.css"
 import * as buttonStyles from "../../styles/button.module.css"
 import * as getStartedStyles from "../../components/GetStarted.module.css"
 import * as codeAreaStyles from "../../components/CodeArea.module.css"
+import ClipBoard from "../../components/ClipBoard"
 
 export default {
   title: "FAQs",
@@ -708,18 +709,11 @@ export default {
           </p>
           <span>
             npm i mutationobserver-shim
-            <button
+            <ClipBoard
               className={getStartedStyles.copyButton}
-              onClick={() => {
-                copyClipBoard("npm i mutationobserver-shim")
-                alert("Code copied into your clipboard.")
-              }}
-            >
-              <span>
-                <span />
-              </span>{" "}
-              Copy
-            </button>
+              onClick={() => copyClipBoard("npm i mutationobserver-shim")}
+              currentLanguage="en"
+            />
           </span>
         </div>
       ),

--- a/src/data/generic.tsx
+++ b/src/data/generic.tsx
@@ -5,6 +5,9 @@ export default {
   copy: {
     en: "Copy",
   },
+  codeCopied: {
+    en: "Copied",
+  },
   required: {
     en: "Required",
   },


### PR DESCRIPTION
## Description 

We are currently opening an `alert` to let you know that the code has been copied. My proposal is to improve the user experience by informing on the button itself that the code is already copied in its transfer area. If this change makes sense, we create this action for the others copy buttons. 

## BEFORE
![ezgif-3-461f27a320](https://user-images.githubusercontent.com/16780687/196250559-36861184-e400-46b6-8b0c-c473810110d0.gif)


## AFTER
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/16780687/196250740-d8373f69-f000-4255-b9fd-4c10330614e0.gif)
