### PR TITLE
fix typo kay->key for list

### DIFF
--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -384,7 +384,7 @@ const { register } = useForm<FormInputs>({
 
             <ul>
               {pages[0].pages.map((page) => (
-                <li kay={page.name}>
+                <li key={page.name}>
                   <p>
                     <Link to={page.pathname}>{page.name}</Link>
                   </p>


### PR DESCRIPTION
Fix for ESLint error - `li` element had `kay` property instead of `key`