### PR TITLE
Enhancement: Input radio validade on page builder

### DIFF
--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -249,8 +249,22 @@ function BuilderPage({
                 type="text"
                 name="options"
                 placeholder="Enter options separate by ;"
-                ref={register}
+                ref={register({
+                  required: true,
+                })}
               />
+              <Animate
+                play={!!errors["options"]}
+                duration={0.6}
+                start={{
+                  maxHeight: 0,
+                }}
+                end={{ maxHeight: 20 }}
+              >
+                {errors.options && errors.options["type"] === "required" && (
+                  <p className={typographyStyles.error}>This is required.</p>
+                )}
+              </Animate>
             </>
           )}
 


### PR DESCRIPTION
I add a required validate on input **radio** and **select** to solve this issue: https://github.com/react-hook-form/documentation/issues/834. 

I think we don't have a bug on this page if you add an `Options` on the page build it will generate a code for you, but if you don't add the `Options` they don't create a code for you. My proposal is required the options field. Looks good for you? 

![ezgif com-gif-maker (7)](https://user-images.githubusercontent.com/16780687/198263117-266e8e1d-2e0f-44db-bf32-9e74485b6cf1.gif)
