### PR TITLE
Fix: Add redirect to legacy api doc

### DIFF
--- a/src/components/ApiGallery.tsx
+++ b/src/components/ApiGallery.tsx
@@ -36,16 +36,20 @@ export default function ApiGallery({ defaultLang }) {
   const onChange = (e) => {
     const version = parseInt(e.target.value)
 
-    navigate(`/v${version}/api/`)
-
     actions.updateSetting({
       version,
     })
+
+    if (version !== 7) {
+      window.location.href = `https://legacy.react-hook-form.com/v${version}/api`
+    } else {
+      navigate(`/v${version}/api/`)
+    }
   }
 
   React.useEffect(() => {
-    if (setting.version !== 7) {
-      setting.version && navigate(`/v${setting.version}/api`)
+    if (setting.version !== 7 && setting.version) {
+      window.location.href = `https://legacy.react-hook-form.com/v${setting.version}/api`
     } else if (window.location.hash) {
       const name = window.location.hash.toLowerCase().slice(1)
 


### PR DESCRIPTION
## Description

Today on the main site(https://react-hook-form.com/) we have a bug when the user access the API documentation and change the **version to 6 or 5**:
![ezgif com-gif-maker (8)](https://user-images.githubusercontent.com/16780687/198717460-32c9665b-ea12-4178-ab21-251e26c561f4.gif)

This bug occurs because we don't have a page folder to v6 and v5 api: 
<img width="457" alt="Captura de Tela 2022-10-28 às 16 27 31" src="https://user-images.githubusercontent.com/16780687/198716908-5eb91149-17c5-4e0a-b087-69493026f661.png">

My proposal is to redirect the user to legacy documentation when they change the version v6(https://legacy.react-hook-form.com/v6/api) and v5(https://legacy.react-hook-form.com/v5/api) documentation. On the legacy we have a page for this versions:
<img width="485" alt="Captura de Tela 2022-10-28 às 16 29 10" src="https://user-images.githubusercontent.com/16780687/198717173-7df58b0c-b854-441f-afcf-4175ecf5877b.png">


Recording the issue fix. 
![ezgif com-gif-maker (9)](https://user-images.githubusercontent.com/16780687/198718011-8f939d62-205a-44b9-9ad6-d0d026b8ba81.gif)

Look good for you? What do you think? 