### PR TITLE
Proposal: redirect button "edit on github" to a correct page

### DIFF
--- a/src/components/logic/getEditLink.tsx
+++ b/src/components/logic/getEditLink.tsx
@@ -1,5 +1,15 @@
 const preFix =
-  "https://github.com/react-hook-form/documentation/edit/master/src/data/"
+  "https://github.com/react-hook-form/documentation/edit/master/src/"
+
+const dataPreFix = "data/"
+const pagesPreFix = "pages/"
+
+const filterApiPageURL = (pathname) => {
+  if (pathname.charAt(pathname.length - 1) === "/")
+    return pathname.substring(0, pathname.length - 1).substring(1)
+
+  return pathname.substring(1)
+}
 
 export const getEditLink = (
   currentLanguage: string,
@@ -8,22 +18,26 @@ export const getEditLink = (
   if (!pathname) return ""
 
   if (pathname === "/" || pathname === "") {
-    return preFix + "home.tsx"
+    return `${preFix}${dataPreFix}/home.tsx`
   } else if (pathname.includes("get-started")) {
-    return `${preFix}${currentLanguage}/getStarted.tsx`
+    return `${preFix}${dataPreFix}${currentLanguage}/getStarted.tsx`
   } else if (pathname.includes("api")) {
-    return `${preFix}${currentLanguage}/api.tsx`
+    const splitPath = pathname.split("/")
+    if (splitPath.length === 2 || splitPath[2] === "") {
+      return `${preFix}${dataPreFix}${currentLanguage}/api.tsx`
+    }
+    return `${preFix}${pagesPreFix}${filterApiPageURL(pathname)}.tsx`
   } else if (pathname.includes("ts")) {
-    return `${preFix}ts.tsx`
+    return `${preFix}${dataPreFix}ts.tsx`
   } else if (pathname.includes("advanced-usage")) {
-    return `${preFix}${currentLanguage}/advanced.tsx`
+    return `${preFix}${dataPreFix}${currentLanguage}/advanced.tsx`
   } else if (pathname.includes("faqs")) {
-    return `${preFix}${currentLanguage}/faq.tsx`
+    return `${preFix}${dataPreFix}${currentLanguage}/faq.tsx`
   } else if (pathname.includes("dev-tools")) {
-    return `${preFix}${currentLanguage}/devtools.tsx`
+    return `${preFix}${dataPreFix}${currentLanguage}/devtools.tsx`
   } else if (pathname.includes("form-builder")) {
-    return `${preFix}builder.tsx`
+    return `${preFix}${dataPreFix}builder.tsx`
   } else if (pathname.includes("resources")) {
-    return `${preFix}resources.tsx`
+    return `${preFix}${dataPreFix}resources.tsx`
   }
 }


### PR DESCRIPTION
Hi, I'm here again! 😊

I proposal a logic to redirect to a correct page when user click on edit button on API pages, today they redirect to api.tsx generic page. (https://github.com/react-hook-form/documentation/edit/master/src/data/en/api.tsx)

My proposal is to redirect to a correct github page with user access on the doc. 

Obs: I create a logic to remove the last "/" if the user access urls to end with ** /**, this break a redirect link to github: 

Example:
- [x] https://react-hook-form.com/api/
- [x] https://react-hook-form.com/api/useform/resetfield/


I think this PR solve this issue: https://github.com/react-hook-form/documentation/issues/831