### PR TITLE
fix typo in design and philosophy section

### DIFF
--- a/src/data/en/getStarted.tsx
+++ b/src/data/en/getStarted.tsx
@@ -191,7 +191,7 @@ export default {
             <p>Avoiding unnecessary computation</p>
           </li>
           <li>
-            <p>Isolating component re-rendering when requires</p>
+            <p>Isolating component re-rendering when required</p>
           </li>
         </ul>
         <p>


### PR DESCRIPTION
Fixed a small typo in 'Design and philosophy' section of 'Get Started' page