### PR TITLE
Update description of "valueAsNumber" option

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -424,7 +424,7 @@ export default function ApiRefTable({
                   </li>
                   <li>
                     <p>
-                      Only applicable and support to {`<input />`}, but we still
+                      Only applicable and support to {`<input type="number" />`}, but we still
                       cast to number type without trim or any other data
                       manipulation.
                     </p>


### PR DESCRIPTION
- Update description of "valueAsNumber" option to be more clear it's specially targeting `<input type="number" />` to avoid confusion.

Reference: https://github.com/react-hook-form/react-hook-form/pull/9299