### PR TITLE
Updating github repo link

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -99,7 +99,7 @@ export default function Nav({ defaultLang }: { defaultLang: string }) {
         </span>
 
         <GitHubButton
-          href="https://github.com/bluebill1049/react-hook-form"
+          href="https://github.com/react-hook-form/react-hook-form"
           data-size="large"
           data-show-count
           aria-label="Star react-hook-form on GitHub"


### PR DESCRIPTION
- Quick fix on the github repository link

![Screen Shot 2023-01-05 at 2 13 49 pm](https://user-images.githubusercontent.com/5287262/210700434-ea68b6e4-04f0-4b06-ba6f-86ec744febb0.png)
