### PR TITLE
Add forgotten control in code example

### DIFF
--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -342,8 +342,8 @@ const onSubmit = (data) => {
   return {show && <input {...register('test')} />}
 }
 
-const Work = () => {
-  const { show } = useWatch()
+const Work = ({ control }) => {
+  const { show } = useWatch({ control })
   // ✅ get notified at useEffect
   return {show && <input {...register('test1')} />}
 }


### PR DESCRIPTION
This is simple and clear. The control prop is not given to useWatch.