### PR TITLE
Fixed undefined error on builder

### DIFF
--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -212,7 +212,7 @@ function BuilderPage({
           <select
             aria-label="Select type"
             name="type"
-            ref={register}
+            ref={register({required: false})}
             defaultValue={editFormData.type}
           >
             <option value="text">Text</option>
@@ -272,7 +272,7 @@ function BuilderPage({
             <input
               type="checkbox"
               name="toggle"
-              ref={register}
+              ref={register({required: false})}
               onClick={() => toggleValidation(!showValidation)}
             />
             {builder.inputCreator[currentLanguage].validation}
@@ -296,7 +296,7 @@ function BuilderPage({
                   marginTop: 0,
                 }}
               >
-                <input type="checkbox" name="required" ref={register} />
+                <input type="checkbox" name="required" ref={register({required: false})} />
                 Required
               </label>
               <label htmlFor="max">Max</label>
@@ -306,7 +306,7 @@ function BuilderPage({
                 autoComplete="false"
                 name="max"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="min">Min</label>
               <input
@@ -315,7 +315,7 @@ function BuilderPage({
                 aria-label="min"
                 name="min"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="maxLength">MaxLength</label>
               <input
@@ -324,7 +324,7 @@ function BuilderPage({
                 aria-label="max length"
                 name="maxLength"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="pattern">Pattern</label>
               <input
@@ -336,7 +336,7 @@ function BuilderPage({
                 aria-label="pattern"
                 name="pattern"
                 type="text"
-                ref={register}
+                ref={register({required: false})}
               />
             </fieldset>
           </Animate>


### PR DESCRIPTION
The BuilderPage had an issue when we create new form fields the code doesn't generates for the validation and type also gets as "undefined" when we create 2 fields in a row.
In the below example I tried to create two field with basic and same configuration without and validation. The first one with the field name "test1" got successful and showed up as per the inputs but for the second input with field name "test2" was created but with undefined as the type of the input as shown in the below picture
![image](https://user-images.githubusercontent.com/26142131/213108484-729c7239-8fb9-4dcf-a52e-ce7dc34396a5.png)
