### PR TITLE
Standardize useForm prop formatting

### DIFF
--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -253,22 +253,17 @@ const { register } = useForm({
 
             {api.useForm.resetOptions}
 
+            <h5 className={typographyStyles.h5} style={{ marginTop: 20 }}>
+              <code>
+                context:{" "}
+                <span className={typographyStyles.typeText}>object</span>
+              </code>
+            </h5>
             <div className={tableStyles.tableWrapper}>
               <table className={tableStyles.table}>
                 <tbody>
                   <tr>
-                    <td>
-                      <p>
-                        <code>context:</code> <br />
-                        <code className={typographyStyles.typeText}>
-                          object
-                        </code>
-                      </p>
-                    </td>
-                    <td>
-                      {api.useForm.validateContext}
-                      <br />
-                    </td>
+                    <td>{api.useForm.validateContext}</td>
                     <td>
                       <CodeSandBoxLink
                         style={codeSandBoxStyle}
@@ -276,15 +271,22 @@ const { register } = useForm({
                       />
                     </td>
                   </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h5 className={typographyStyles.h5} style={{ marginTop: 20 }}>
+              <code>
+                criteriaMode:{" "}
+                <span className={typographyStyles.typeText}>
+                  firstError | all
+                </span>
+              </code>
+            </h5>
+            <div className={tableStyles.tableWrapper}>
+              <table className={tableStyles.table}>
+                <tbody>
                   <tr>
-                    <td>
-                      <p>
-                        <code>criteriaMode</code> <br />
-                        <code className={typographyStyles.typeText}>
-                          firstError | all
-                        </code>
-                      </p>
-                    </td>
                     <td>{api.useForm.validateCriteriaMode}</td>
                     <td>
                       <CodeSandBoxLink
@@ -293,28 +295,38 @@ const { register } = useForm({
                       />
                     </td>
                   </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h5 className={typographyStyles.h5} style={{ marginTop: 20 }}>
+              <code>
+                shouldFocusError:{" "}
+                <span className={typographyStyles.typeText}>
+                  boolean = true
+                </span>
+              </code>
+            </h5>
+            <div className={tableStyles.tableWrapper}>
+              <table className={tableStyles.table}>
+                <tbody>
                   <tr>
-                    <td>
-                      <p>
-                        <code>shouldFocusError</code>
-                        <br />
-                        <code className={typographyStyles.typeText}>
-                          boolean = true
-                        </code>
-                      </p>
-                    </td>
                     <td>{api.useForm.submitFocusError}</td>
                   </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <h5 className={typographyStyles.h5} style={{ marginTop: 20 }}>
+              <code>
+                delayError:{" "}
+                <span className={typographyStyles.typeText}>number</span>
+              </code>
+            </h5>
+            <div className={tableStyles.tableWrapper}>
+              <table className={tableStyles.table}>
+                <tbody>
                   <tr>
-                    <td>
-                      <p>
-                        <code>delayError</code>
-                        <br />
-                        <code className={typographyStyles.typeText}>
-                          number
-                        </code>
-                      </p>
-                    </td>
                     <td>{api.useForm.delayError}</td>
                     <td>
                       <CodeSandBoxLink


### PR DESCRIPTION
UseForm.tsx uses h5 for prop parameters, and includes a special table for some of them. But the styling on prop names within the table is different than the styling for others. This resulted in my initial confusion about which fields were properties of useForm, and if there was some other detail related to prop resetOptions.

This PR removes the table wrapping those properties and aligns the prop names with the same styling h5>code as the others. New tables are used for each prop to show the description on the left and a link to the CodeSandBox on the right.

Anomalies:

- The prop name is now above the description, as with other props, and is followed by a light-blue border-bottom. Unfortunately after the border bottom for these labels, the div>table for the description is slighly further below the line than other props.
- The CodeSandBox links for each prop are not horizontally aligned with different tables the way they are with a single table. I don't think this is a problem - I'm just pointing it out if someone wants to be meticulous about getting the exact same L&F aside from the h5 labels.
- It might be nicer if text `For example: register('test') // doesn't work` were on a separate line that didn't wrap.

I'll take another shot at this if required - with an update to this or in a later patch.

# Screenshots

----

## Before
![image](https://user-images.githubusercontent.com/499473/213817268-a21eb51d-f458-48cb-9880-577afb73b4cb.png)

## After
![image](https://user-images.githubusercontent.com/499473/213817533-96764659-e9f7-4ac8-b3b6-7d9876147c52.png)
