### PR TITLE
Fixed issue with validation checkbox

### DIFF
--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -212,7 +212,7 @@ function BuilderPage({
           <select
             aria-label="Select type"
             name="type"
-            ref={register}
+            ref={register({required: false})}
             defaultValue={editFormData.type}
           >
             <option value="text">Text</option>
@@ -272,7 +272,7 @@ function BuilderPage({
             <input
               type="checkbox"
               name="toggle"
-              ref={register}
+              ref={register({required: false})}
               onClick={() => toggleValidation(!showValidation)}
             />
             {builder.inputCreator[currentLanguage].validation}
@@ -296,7 +296,7 @@ function BuilderPage({
                   marginTop: 0,
                 }}
               >
-                <input type="checkbox" name="required" ref={register} />
+                <input type="checkbox" name="required" ref={register({required: false})} />
                 Required
               </label>
               <label htmlFor="max">Max</label>
@@ -306,7 +306,7 @@ function BuilderPage({
                 autoComplete="false"
                 name="max"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="min">Min</label>
               <input
@@ -315,7 +315,7 @@ function BuilderPage({
                 aria-label="min"
                 name="min"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="maxLength">MaxLength</label>
               <input
@@ -324,7 +324,7 @@ function BuilderPage({
                 aria-label="max length"
                 name="maxLength"
                 type="number"
-                ref={register}
+                ref={register({required: false})}
               />
               <label htmlFor="pattern">Pattern</label>
               <input
@@ -336,7 +336,7 @@ function BuilderPage({
                 aria-label="pattern"
                 name="pattern"
                 type="text"
-                ref={register}
+                ref={register({required: false})}
               />
             </fieldset>
           </Animate>

--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -82,6 +82,7 @@ function BuilderPage({
   const closeButton = useRef(null)
   const [showValidation, toggleValidation] = useState(false)
   const onSubmit = (data) => {
+    toggleValidation(false)
     if (editIndex >= 0) {
       formData[editIndex] = data
       updateFormData([...formData.filter((formInput) => formInput)])
@@ -212,7 +213,7 @@ function BuilderPage({
           <select
             aria-label="Select type"
             name="type"
-            ref={register({required: false})}
+            ref={register({ required: false })}
             defaultValue={editFormData.type}
           >
             <option value="text">Text</option>
@@ -272,7 +273,7 @@ function BuilderPage({
             <input
               type="checkbox"
               name="toggle"
-              ref={register({required: false})}
+              ref={register({ required: false })}
               onClick={() => toggleValidation(!showValidation)}
             />
             {builder.inputCreator[currentLanguage].validation}
@@ -296,7 +297,11 @@ function BuilderPage({
                   marginTop: 0,
                 }}
               >
-                <input type="checkbox" name="required" ref={register({required: false})} />
+                <input
+                  type="checkbox"
+                  name="required"
+                  ref={register({ required: false })}
+                />
                 Required
               </label>
               <label htmlFor="max">Max</label>
@@ -306,7 +311,7 @@ function BuilderPage({
                 autoComplete="false"
                 name="max"
                 type="number"
-                ref={register({required: false})}
+                ref={register({ required: false })}
               />
               <label htmlFor="min">Min</label>
               <input
@@ -315,7 +320,7 @@ function BuilderPage({
                 aria-label="min"
                 name="min"
                 type="number"
-                ref={register({required: false})}
+                ref={register({ required: false })}
               />
               <label htmlFor="maxLength">MaxLength</label>
               <input
@@ -324,7 +329,7 @@ function BuilderPage({
                 aria-label="max length"
                 name="maxLength"
                 type="number"
-                ref={register({required: false})}
+                ref={register({ required: false })}
               />
               <label htmlFor="pattern">Pattern</label>
               <input
@@ -336,7 +341,7 @@ function BuilderPage({
                 aria-label="pattern"
                 name="pattern"
                 type="text"
-                ref={register({required: false})}
+                ref={register({ required: false })}
               />
             </fieldset>
           </Animate>


### PR DESCRIPTION
Validation checkbox issue whenever used the validation popup isn't hidden by default from the user.

Test performed:
The following was submitted for the first time
![image](https://user-images.githubusercontent.com/26142131/213903490-c1ea1788-167b-4dbe-9a23-987066be7765.png)
and after clicking on create the validation popup (which contains required, min, max fields) continued to show up while the checkbox was unchecked
![image](https://user-images.githubusercontent.com/26142131/213903521-99fcd726-8765-4bff-8ff5-978460856ba2.png)

Modified: When clicking on create the state of popup was changed to make sure the popup is hidden