### PR TITLE
Remove unnecessary optional chaining

### DIFF
--- a/src/content/get-started.mdx
+++ b/src/content/get-started.mdx
@@ -628,7 +628,7 @@ export default function App() {
         {...register("mail", { required: "Email Address is required" })}
         aria-invalid={errors.mail ? "true" : "false"}
       />
-      {errors.mail && <p role="alert">{errors.mail?.message}</p>}
+      {errors.mail && <p role="alert">{errors.mail.message}</p>}
 
       <input type="submit" />
     </form>


### PR DESCRIPTION
This optional chaining is unnecessary because `errors.mail` at the beginning of the line ensures `errors.mail` is not nullish.