### PR TITLE
Fix: `cannot find IFormInput name` error in  code examples.

### DIFF
--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -182,8 +182,14 @@ export const uiLibraryHookInputTs = `import Select from "react-select";
 import { useForm, Controller, SubmitHandler } from "react-hook-form";
 import Input from "@material-ui/core/Input";
 
+interface IFormInput {
+  firstName: string;
+  lastName: string;
+  iceCreamType: { label: string; value: string };
+}
+
 const App = () => {
-  const { control, handleSubmit } = useForm({
+  const { control, handleSubmit } = useForm<IFormInput>({
     defaultValues: {
       firstName: '',
       lastName: '',

--- a/src/components/codeExamples/getStarted.ts
+++ b/src/components/codeExamples/getStarted.ts
@@ -189,7 +189,7 @@ interface IFormInput {
 }
 
 const App = () => {
-  const { control, handleSubmit } = useForm<IFormInput>({
+  const { control, handleSubmit } = useForm({
     defaultValues: {
       firstName: '',
       lastName: '',


### PR DESCRIPTION
### Description

- The ts code example in the section `Integrating with UI libraries`  in the get started page is missing the `IFormInput` interface.
- But the codeSandbox includes the `IFormInput` interface, so this pull request adds the same.
- It is being used  in the ts example code already, only the definition is missing.
https://github.com/react-hook-form/documentation/blob/a9d51013cd265cbbb7d40a53a6c4a09b97e04c67/src/components/codeExamples/getStarted.ts#L194