### PR TITLE
Fixed typos in watch pages

### DIFF
--- a/src/components/ApiWatch.tsx
+++ b/src/components/ApiWatch.tsx
@@ -107,7 +107,7 @@ export default function ApiWatch({
                 <code>watch('inputName')</code>
               </td>
               <td>
-                <code className={typographyStyles.typeText}>unkown</code>
+                <code className={typographyStyles.typeText}>unknown</code>
               </td>
             </tr>
             <tr>

--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -140,7 +140,7 @@ export default function UseFieldArray({
                 <code>useWatch('inputName')</code>
               </td>
               <td>
-                <code className={typographyStyles.typeText}>unkown</code>
+                <code className={typographyStyles.typeText}>unknown</code>
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
This is for the legacy docs. I found a type while checking `useWatch` documentation. Fixing it here.