### PR TITLE
fixing lighthouse for commits

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -7,16 +7,17 @@ jobs:
     name: Lighthouse
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 14.x
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
-      - name: npm install, build
+          node-version: 18
+      - name: npm install
         run: |
-          npm install
+          npm install --legacy-peer-deps && npm install -g @lhci/cli@0.11.x
+      - name: build
+        run: |
           npm run build
       - name: run Lighthouse CI
         run: |
-          npm install -g @lhci/cli@0.5.x
-          lhci autorun
+          lhci autorun --collect.autodiscoverUrlBlocklist="_gatsby/slices/_gatsby-scripts-1.html"

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  collect: {
+    autodiscoverUrlBlocklist: ["_gatsby/slices/_gatsby-scripts-1.html"],
+  },
   ci: {
     upload: {
       target: "temporary-public-storage",


### PR DESCRIPTION
Noticed last 2 commits failed on lighthouse check.

Seems like a simple update to use latest action version + nodejs 16

Related to https://github.com/GoogleChrome/lighthouse-ci/issues/842