### PR TITLE
Documentation: Fix the spelling of 'built-in'

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -547,7 +547,7 @@ export default function ApiRefTable({ api }) {
                 <ul>
                   <p>
                     <code>Disabled</code> prop will also omit{" "}
-                    <strong>build-in</strong> validation rules.
+                    <strong>built-in</strong> validation rules.
                   </p>
                   <p>
                     For schema validation, you can leverage the{" "}

--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -178,7 +178,7 @@ export default ({ currentLanguage }) => {
                   <a href="#shouldFocusError">shouldFocusError</a>
                 </td>
                 <td>
-                  <p>enable or disable build-in focus management.</p>
+                  <p>enable or disable built-in focus management.</p>
                 </td>
               </tr>
               <tr>
@@ -196,7 +196,7 @@ export default ({ currentLanguage }) => {
                   </a>
                 </td>
                 <td>
-                  <p>use browser build-in form constraint API.</p>
+                  <p>use browser built-in form constraint API.</p>
                 </td>
               </tr>
               <tr>

--- a/src/components/useForm/UnRegister.tsx
+++ b/src/components/useForm/UnRegister.tsx
@@ -192,8 +192,8 @@ export default ({ currentLanguage }) => {
             <ul>
               <li>
                 <p>
-                  This method will remove input reference and its value which
-                  means <b>build-in validation</b> rules will be removed as
+                  This method will remove input reference and its value, which
+                  means <b>built-in validation</b> rules will be removed as
                   well.
                 </p>
               </li>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -299,7 +299,7 @@ const onSubmit = (data) => {
           <li>
             <p>
               By default <code>shouldUnregister: false</code>: unmounted fields
-              will <strong>not</strong> be validated by build-in validation.
+              will <strong>not</strong> be validated by built-in validation.
             </p>
           </li>
           <li>
@@ -1310,7 +1310,7 @@ setError('registerInput', { type: 'custom', message: 'custom message' });
             <p>
               An error that is not associated with an input field will be
               persisted until cleared with <code>clearErrors</code>. This
-              behaviour is only applicable for build in validation at field
+              behaviour is only applicable for built-in validation at field
               level.
             </p>
             <CodeArea


### PR DESCRIPTION
I've noticed that the phrase `build-in` is used throughout the code, however the correct spelling is [built-in](https://www.merriam-webster.com/thesaurus/built-in). This PR replaces all the occurrences of build-in with built-in. 