### PR TITLE
Documentation: useForm fixes and updates

### DIFF
--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -518,24 +518,29 @@ export default ({ currentLanguage }) => {
                 browser native validation
               </a>
               . It will also enable CSS selectors <code>:valid</code> and
-              <code>:invalid</code> making style inputs easier. In fact, you can
-              still use those selectors even the client validation is disabled.
+              <code>:invalid</code> making styling inputs easier. You can still
+              use these selectors even when client-side validation is disabled.
             </p>
             <ul>
               <li>
-                Only works with onSubmit and onChange mode due to{" "}
-                <code>reportValidity</code> execution will focus on the error
-                input.
-              </li>
-              <li>
-                Each registered field's validation message is required to be
-                string to display them natively.
+                <p>
+                  Only works with <code>onSubmit</code> and{" "}
+                  <code>onChange</code> modes, as the{" "}
+                  <code>reportValidity</code> execution will focus the error
+                  input.
+                </p>
               </li>
               <li>
                 <p>
-                  This feature only works for <code>register</code> API, and{" "}
-                  <code>useController/Controller</code> which wired with actual
-                  DOM reference.
+                  Each registered field's validation message is required to be
+                  string to display them natively.
+                </p>
+              </li>
+              <li>
+                <p>
+                  This feature only works with the <code>register</code> API and
+                  <code>useController/Controller</code> that are connected with
+                  actual DOM references.
                 </p>
               </li>
             </ul>

--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -118,95 +118,97 @@ export default ({ currentLanguage }) => {
             </p>
 
             <table className={tableStyles.table}>
-              <tr>
-                <td>
-                  <a href="#mode">mode</a>
-                </td>
-                <td>
-                  <p>
-                    validation strategy <b>before</b> submitting behaviour.
-                  </p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#reValidateMode">reValidateMode</a>
-                </td>
-                <td>
-                  <p>
-                    validation strategy <b>after</b> submitting behaviour.
-                  </p>
-                </td>
-              </tr>
-              <tr>
-                <td width={250}>
-                  <a href="#defaultValues">defaultValues</a>
-                </td>
-                <td>
-                  <p>default values for the form.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#values">values</a>
-                </td>
-                <td>
-                  <p>reactive values to update the form values.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#resetOptions">resetOptions</a>
-                </td>
-                <td>
-                  <p>
-                    option to reset form state update while updating new form
-                    values.
-                  </p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#criteriaMode">criteriaMode</a>
-                </td>
-                <td>
-                  <p>Display all validation errors or one at a time.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#shouldFocusError">shouldFocusError</a>
-                </td>
-                <td>
-                  <p>enable or disable built-in focus management.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#delayError">delayError</a>
-                </td>
-                <td>
-                  <p>delay error from appearing instantly.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#shouldUseNativeValidation">
-                    shouldUseNativeValidation
-                  </a>
-                </td>
-                <td>
-                  <p>use browser built-in form constraint API.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#shouldUnregister">shouldUnregister</a>
-                </td>
-                <td>
-                  <p>enable and disable input unregister after unmount.</p>
-                </td>
-              </tr>
+              <tbody>
+                <tr>
+                  <td>
+                    <a href="#mode">mode</a>
+                  </td>
+                  <td>
+                    <p>
+                      validation strategy <b>before</b> submitting behaviour.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#reValidateMode">reValidateMode</a>
+                  </td>
+                  <td>
+                    <p>
+                      validation strategy <b>after</b> submitting behaviour.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td width={250}>
+                    <a href="#defaultValues">defaultValues</a>
+                  </td>
+                  <td>
+                    <p>default values for the form.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#values">values</a>
+                  </td>
+                  <td>
+                    <p>reactive values to update the form values.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#resetOptions">resetOptions</a>
+                  </td>
+                  <td>
+                    <p>
+                      option to reset form state update while updating new form
+                      values.
+                    </p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#criteriaMode">criteriaMode</a>
+                  </td>
+                  <td>
+                    <p>Display all validation errors or one at a time.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#shouldFocusError">shouldFocusError</a>
+                  </td>
+                  <td>
+                    <p>enable or disable built-in focus management.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#delayError">delayError</a>
+                  </td>
+                  <td>
+                    <p>delay error from appearing instantly.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#shouldUseNativeValidation">
+                      shouldUseNativeValidation
+                    </a>
+                  </td>
+                  <td>
+                    <p>use browser built-in form constraint API.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#shouldUnregister">shouldUnregister</a>
+                  </td>
+                  <td>
+                    <p>enable and disable input unregister after unmount.</p>
+                  </td>
+                </tr>
+              </tbody>
             </table>
 
             <p>
@@ -214,22 +216,26 @@ export default ({ currentLanguage }) => {
             </p>
 
             <table className={tableStyles.table}>
-              <tr>
-                <td width={250}>
-                  <a href="#resolver">resolver</a>
-                </td>
-                <td>
-                  <p>to plugin with your favour schema validation library.</p>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <a href="#context">context</a>
-                </td>
-                <td>
-                  <p>A context object to supply for your schema validation.</p>
-                </td>
-              </tr>
+              <tbody>
+                <tr>
+                  <td width={250}>
+                    <a href="#resolver">resolver</a>
+                  </td>
+                  <td>
+                    <p>to plugin with your favour schema validation library.</p>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="#context">context</a>
+                  </td>
+                  <td>
+                    <p>
+                      A context object to supply for your schema validation.
+                    </p>
+                  </td>
+                </tr>
+              </tbody>
             </table>
 
             <h2 id="props" className={typographyStyles.subTitle}>

--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -125,7 +125,7 @@ export default ({ currentLanguage }) => {
                   </td>
                   <td>
                     <p>
-                      validation strategy <b>before</b> submitting behaviour.
+                      Validation strategy <b>before</b> submitting behaviour.
                     </p>
                   </td>
                 </tr>
@@ -135,7 +135,7 @@ export default ({ currentLanguage }) => {
                   </td>
                   <td>
                     <p>
-                      validation strategy <b>after</b> submitting behaviour.
+                      Validation strategy <b>after</b> submitting behaviour.
                     </p>
                   </td>
                 </tr>
@@ -144,7 +144,7 @@ export default ({ currentLanguage }) => {
                     <a href="#defaultValues">defaultValues</a>
                   </td>
                   <td>
-                    <p>default values for the form.</p>
+                    <p>Default values for the form.</p>
                   </td>
                 </tr>
                 <tr>
@@ -152,7 +152,7 @@ export default ({ currentLanguage }) => {
                     <a href="#values">values</a>
                   </td>
                   <td>
-                    <p>reactive values to update the form values.</p>
+                    <p>Reactive values to update the form values.</p>
                   </td>
                 </tr>
                 <tr>
@@ -161,7 +161,7 @@ export default ({ currentLanguage }) => {
                   </td>
                   <td>
                     <p>
-                      option to reset form state update while updating new form
+                      Option to reset form state update while updating new form
                       values.
                     </p>
                   </td>
@@ -179,7 +179,7 @@ export default ({ currentLanguage }) => {
                     <a href="#shouldFocusError">shouldFocusError</a>
                   </td>
                   <td>
-                    <p>enable or disable built-in focus management.</p>
+                    <p>Enable or disable built-in focus management.</p>
                   </td>
                 </tr>
                 <tr>
@@ -187,7 +187,7 @@ export default ({ currentLanguage }) => {
                     <a href="#delayError">delayError</a>
                   </td>
                   <td>
-                    <p>delay error from appearing instantly.</p>
+                    <p>Delay error from appearing instantly.</p>
                   </td>
                 </tr>
                 <tr>
@@ -197,7 +197,7 @@ export default ({ currentLanguage }) => {
                     </a>
                   </td>
                   <td>
-                    <p>use browser built-in form constraint API.</p>
+                    <p>Use browser built-in form constraint API.</p>
                   </td>
                 </tr>
                 <tr>
@@ -205,7 +205,7 @@ export default ({ currentLanguage }) => {
                     <a href="#shouldUnregister">shouldUnregister</a>
                   </td>
                   <td>
-                    <p>enable and disable input unregister after unmount.</p>
+                    <p>Enable and disable input unregister after unmount.</p>
                   </td>
                 </tr>
               </tbody>
@@ -222,7 +222,9 @@ export default ({ currentLanguage }) => {
                     <a href="#resolver">resolver</a>
                   </td>
                   <td>
-                    <p>to plugin with your favour schema validation library.</p>
+                    <p>
+                      Integrates with your preferred schema validation library.
+                    </p>
                   </td>
                 </tr>
                 <tr>

--- a/src/components/UseForm.tsx
+++ b/src/components/UseForm.tsx
@@ -261,8 +261,8 @@ export default ({ currentLanguage }) => {
             <div className={tableStyles.tableWrapper}>
               <p>
                 This option allows you to configure the validation strategy
-                before a user submits the form that is happened during{" "}
-                <code>onSubmit</code> event by invoking{" "}
+                before a user submits the form. The validation occurs during the{" "}
+                <code>onSubmit</code> event, which is triggered by invoking the{" "}
                 <Link to="/api/useform/handlesubmit">
                   <code>handleSubmit</code>
                 </Link>{" "}

--- a/src/components/ValidationResolver.tsx
+++ b/src/components/ValidationResolver.tsx
@@ -89,7 +89,7 @@ export default function ({ api }) {
               </td>
               <td>
                 <p>
-                  This is the option object contains information about the
+                  This is the option object containing information about the
                   validated fields, names and <code>criteriaMode</code> from{" "}
                   <code>useForm</code>.
                 </p>
@@ -106,9 +106,9 @@ export default function ({ api }) {
       <ul>
         <li>
           <p>
-            Schema validation focus on the field level for error reporting.
-            Parent level error look is only limited to the direct parent level
-            that is applicable for components such as group checkboxes.
+            Schema validation focuses on field-level error reporting.
+            Parent-level error checking is limited to the direct parent level,
+            which is applicable for components such as group checkboxes.
           </p>
         </li>
 
@@ -137,8 +137,8 @@ export default function ({ api }) {
           <ul>
             <li>
               <p>
-                Make sure you are returning an object that has both a{" "}
-                <code>values</code> and an <code>errors</code> property. Their
+                Make sure that you return an object with both{" "}
+                <code>values</code> and <code>errors</code> properties. Their
                 default values should be an empty object. For example:{" "}
                 <code>{`{}`}</code>.
               </p>

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -62,33 +62,33 @@ export default {
     ),
     validateOnSubmit: (
       <>
-        Validation will trigger on the <code>submit</code> event and inputs will
-        attach <code>onChange</code> event listeners to re-validate them.
+        Validation is triggered on the <code>submit</code> event, and inputs
+        attach <code>onChange</code> event listeners to re-validate themselves.
       </>
     ),
     validateOnBlur: (
       <>
-        Validation will trigger on the <code>blur</code> event.
+        Validation is triggered on the <code>blur</code> event.
       </>
     ),
     validateOnChange: (
       <>
-        Validation will trigger on the <code>change</code> event with each
-        input, and lead to multiple re-renders. Warning: this often comes with a
-        significant impact on performance.
+        Validation is triggered on the <code>change</code>
+        event for each input, leading to multiple re-renders. Warning: this
+        often comes with a significant impact on performance.
       </>
     ),
     validationOnAll: (
       <>
-        Validation will trigger on the <code>blur</code> and <code>change</code>{" "}
-        events.
+        Validation is triggered on both <code>blur</code> and{" "}
+        <code>change</code> events.
       </>
     ),
     validationOnTouched: (
       <>
         <p>
-          Validation will trigger on the first <code>blur</code> event. After
-          that, it will trigger on every <code>change</code> event.
+          Validation is initially triggered on the first <code>blur</code>{" "}
+          event. After that, it is triggered on every <code>change</code> event.
         </p>
         <p>
           <b className={typographyStyles.note}>Note:</b> when using with{" "}

--- a/src/data/en/api.tsx
+++ b/src/data/en/api.tsx
@@ -131,12 +131,12 @@ function App() {
     resetOptions: (
       <>
         <p>
-          This property is associated with value update behaviours. In fact,{" "}
-          <code>values</code> or <code>defaultValues</code> update will invoke
-          the <code>reset</code> API internally. So it's important to info what
-          behaviour should be after the <code>values</code> or{" "}
-          <code>defaultValues</code> get asynchronously updated. The config
-          option itself is a reference to{" "}
+          This property is related to value update behaviors. When{" "}
+          <code>values</code> or <code>defaultValues</code> are updated, the{" "}
+          <code>reset</code> API is invoked internally. It's important to
+          specify the desired behavior after <code>values</code> or{" "}
+          <code>defaultValues</code> are asynchronously updated. The
+          configuration option itself is a reference to the{" "}
           <Link to="/api/useform/reset">reset</Link> method's options.
         </p>
 
@@ -162,17 +162,17 @@ useForm({
     defaultValues: (
       <>
         <p>
-          The <code>defaultValues</code> prop is used to populate the entire
-          form values. It supports both sync and async set form default values.
-          You can set an input's default value with <code>defaultValue</code>/
-          <code>defaultChecked</code>{" "}
+          The <code>defaultValues</code> prop populates the entire form with
+          default values. It supports both synchronous and asynchronous
+          assignment of default values. While you can set an input's default
+          value using <code>defaultValue</code> or <code>defaultChecked</code>{" "}
           <a
             className={buttonStyles.links}
             href="https://reactjs.org/docs/uncontrolled-components.html"
           >
-            (read more from the official React doc)
+            (as detailed in the official React documentation)
           </a>
-          , but it is <b>encouraged</b> that you set <code>defaultValues</code>{" "}
+          , it is <strong>recommended</strong> to use <code>defaultValues</code>{" "}
           for the entire form.
         </p>
 
@@ -196,17 +196,15 @@ useForm({
         <ul>
           <li>
             <p>
-              You <b>should</b> provide <b>none</b> <code>undefined</code>{" "}
-              default value, as <code>undefined</code> value is conflicting with
-              controlled component as default state.
+              You <strong>should avoid</strong> providing <code>undefined</code>{" "}
+              as a default value, as it conflicts with the default state of a
+              controlled component.
             </p>
           </li>
           <li>
             <p>
-              {" "}
-              <code>defaultValues</code> are cached. If you want to reset the{" "}
-              <code>defaultValues</code>, you should use the{" "}
-              <Link to="/api/useform/reset">reset</Link> api.
+              <code>defaultValues</code> are cached. To reset them, use the{" "}
+              <Link to="/api/useform/reset">reset</Link> API.
             </p>
           </li>
           <li>
@@ -217,13 +215,13 @@ useForm({
           </li>
           <li>
             <p>
-              It's recommend to avoid including custom object which contains
-              prototype methods as the <code>defaultValues</code>, such as{" "}
-              <code>moment</code>, <code>luxon</code> and etc.
+              It's recommended to avoid using custom objects containing
+              prototype methods, such as <code>Moment</code> or{" "}
+              <code>Luxon</code>, as <code>defaultValues</code>.
             </p>
           </li>
           <li>
-            <p>There are other options to include form data:</p>
+            <p>There are other options for including form data:</p>
             <CodeArea
               rawData={`// include hidden input
 <input {...register("hidden")} type="hidden" />
@@ -250,8 +248,8 @@ const onSubmit = (data) => {
         <Link to="/api/useform/handlesubmit">
           <code>handleSubmit</code>
         </Link>{" "}
-        function executed). By default, re-validation is actioned during the
-        input change event.
+        function executed). By default, re-validation occurs during the input
+        change event.
       </p>
     ),
     validationFields: (
@@ -264,8 +262,8 @@ const onSubmit = (data) => {
     submitFocusError: (
       <>
         <p>
-          When set to true (default) and the user submits a form that fails the
-          validation, it will set focus on the first field with an error.
+          When set to <code>true</code> (default), and the user submits a form
+          that fails validation, focus is set on the first field with an error.
         </p>
 
         <p>
@@ -291,15 +289,15 @@ const onSubmit = (data) => {
         <ul>
           <li>
             <p>
-              This is a global config that overwrites child-level config, if you
-              want to have individual behavior, then you should set the config
+              This is a global configuration that overrides child-level
+              configurations. To have individual behavior, set the configuration
               at the component or hook level, not at <code>useForm</code>.
             </p>
           </li>
           <li>
             <p>
-              By default <code>shouldUnregister: false</code>: unmounted fields
-              will <strong>not</strong> be validated by built-in validation.
+              By default, <code>shouldUnregister: false</code> means unmounted
+              fields are <strong>not validated</strong> by built-in validation.
             </p>
           </li>
           <li>
@@ -311,28 +309,31 @@ const onSubmit = (data) => {
           </li>
           <li>
             <p>
-              set <code>shouldUnregister: true</code> will set your form behave
-              more closer as native.
+              Setting <code>shouldUnregister: true</code> makes your form behave
+              more closely to native forms.
             </p>
-            <p>Form values will be lived inside your inputs itself.</p>
             <ul>
               <li>
-                <p>input unmount will remove value.</p>
+                <p>Form values are stored within the inputs themselves.</p>
               </li>
               <li>
-                <p>input hidden should be applied for hidden data.</p>
+                <p>Unmounting an input removes its value.</p>
               </li>
               <li>
                 <p>
-                  only registered input will be included as submission data.
+                  Hidden inputs should use the <code>hidden</code> attribute for
+                  storing hidden data.
                 </p>
               </li>
               <li>
+                <p>Only registered inputs are included as submission data.</p>
+              </li>
+              <li>
                 <p>
-                  unmounted input will need to notify at either{" "}
-                  <code>useForm</code>, or <code>useWatch</code>'s{" "}
-                  <code>useEffect</code> for hook form to verify input is
-                  unmounted from the DOM.
+                  Unmounted inputs must be notified at either{" "}
+                  <code>useForm</code> or <code>useWatch</code>'s{" "}
+                  <code>useEffect</code> for the hook form to verify that the
+                  input is unmounted from the DOM.
                 </p>
 
                 <CodeArea
@@ -370,9 +371,9 @@ const App = () => {
     ),
     delayError: (
       <p>
-        This config will delay the error state to be displayed to the end-user
-        in milliseconds. Correct the error input will remove the error instantly
-        and delay will not be applied.
+        This configuration delays the display of error states to the end-user by
+        a specified number of milliseconds. If the user corrects the error
+        input, the error is removed instantly, and the delay is not applied.
       </p>
     ),
   },


### PR DESCRIPTION
Update the documentation for the [useForm](https://react-hook-form.com/api/useform/) page:
- Add missing `tbody` tags inside tables to fix invalid DOM nesting warnings.
- Add consistent capitalisation of list items.
- Add a few missing `p` wrappers for the text.
- Misc grammar and spelling fixes, plus some improved readability. 