### PR TITLE
fix: update useWatch hook documentation

### DIFF
--- a/src/components/UseWatchContent.tsx
+++ b/src/components/UseWatchContent.tsx
@@ -137,7 +137,7 @@ export default function UseFieldArray({
             </tr>
             <tr>
               <td>
-                <code>useWatch('inputName')</code>
+                <code>useWatch({`{ name: 'inputName' }`})</code>
               </td>
               <td>
                 <code className={typographyStyles.typeText}>unknown</code>
@@ -145,7 +145,7 @@ export default function UseFieldArray({
             </tr>
             <tr>
               <td>
-                <code>useWatch(['inputName1'])</code>
+                <code>useWatch({`{ name: ['inputName1'] }`})</code>
               </td>
               <td>
                 <code className={typographyStyles.typeText}>unknown[]</code>


### PR DESCRIPTION
# Description
This PR updates the documentation of the `useWatch` hook. The **Return**  section was confusing as it implied devs could pass a `string` as an argument to `useWatch` to get a field's value. Instead, they have to pass an object with a `name` property.


Closes #927 

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/47266830/229382376-78a51289-65d5-4e2c-8ce4-147aae69c53a.png)
### After
![image](https://user-images.githubusercontent.com/47266830/229382347-d345d1bf-f84d-4d17-bd2b-1cf56ef60f19.png)
