### PR TITLE
Replaced not existing style attribute for placeholder

### DIFF
--- a/src/components/codeExamples/reactNativeController.ts
+++ b/src/components/codeExamples/reactNativeController.ts
@@ -19,7 +19,7 @@ export default function App() {
         }}
         render={({ field: { onChange, onBlur, value } }) => (
           <TextInput
-            style={styles.input}
+            placeholder="First name"
             onBlur={onBlur}
             onChangeText={onChange}
             value={value}
@@ -36,7 +36,7 @@ export default function App() {
         }}
         render={({ field: { onChange, onBlur, value } }) => (
           <TextInput
-            style={styles.input}
+            placeholder="Last name"
             onBlur={onBlur}
             onChangeText={onChange}
             value={value}


### PR DESCRIPTION
While looking at the documentation of React Hook Form for React Native, the example code gave an error because of a not existing style. 

I removed this and replaced it with a placeholder, now the code works directly.