### PR TITLE
Fix/#930 shrinking input

### DIFF
--- a/src/components/Watcher.module.css
+++ b/src/components/Watcher.module.css
@@ -31,6 +31,7 @@
 .watchGroup input[type="checkbox"]:checked {
   border: 1px solid white;
   background: white;
+  min-width: 20px;
 }
 
 .svgWrapper svg {

--- a/src/components/Watcher.tsx
+++ b/src/components/Watcher.tsx
@@ -144,7 +144,7 @@ export default ({
                 ref={register}
                 name="test"
                 className={formStyles.input}
-                maxLength={20}
+                maxLength={19}
               />
             </Animate>
           </section>

--- a/src/components/codeExamples/reactNativeController.ts
+++ b/src/components/codeExamples/reactNativeController.ts
@@ -19,7 +19,7 @@ export default function App() {
         }}
         render={({ field: { onChange, onBlur, value } }) => (
           <TextInput
-            style={styles.input}
+            placeholder="First name"
             onBlur={onBlur}
             onChangeText={onChange}
             value={value}
@@ -36,7 +36,7 @@ export default function App() {
         }}
         render={({ field: { onChange, onBlur, value } }) => (
           <TextInput
-            style={styles.input}
+            placeholder="Last name"
             onBlur={onBlur}
             onChangeText={onChange}
             value={value}


### PR DESCRIPTION
When given a string that was too long, the input checkbox on the end would shrink. This has been fixed by giving it a min-width. On the mobile view the last char would get chopped of, for this reason also the char limit has been decreased by one.

closes #930