### PR TITLE
fix: typo in TS Support FieldArrayWithId

### DIFF
--- a/src/data/ts.tsx
+++ b/src/data/ts.tsx
@@ -502,7 +502,7 @@ export default function App() {
     title: "FieldArrayWithId",
     description: (
       <CodeArea
-        rawData={`export export type FieldArrayWithId<
+        rawData={`export type FieldArrayWithId<
   TFieldValues extends FieldValues = FieldValues,
   TFieldArrayName extends FieldArrayPath<TFieldValues> = FieldArrayPath<TFieldValues>,
   TKeyName extends string = 'id',


### PR DESCRIPTION
"export" word in docs was written twice