### PR TITLE
Example in zod validation resolver doesn't work

### DIFF
--- a/src/components/codeExamples/zodResolver.ts
+++ b/src/components/codeExamples/zodResolver.ts
@@ -16,7 +16,7 @@ const App = () => {
   return (
     <form onSubmit={handleSubmit(d => console.log(d))}>
       <input {...register("name")} />
-      <input {...register("age")} type="number" />
+      <input {...register("age", { valueAsNumber: true })} type="number" />
       <input type="submit" />
     </form>
   );

--- a/src/components/codeExamples/zodResolverTs.ts
+++ b/src/components/codeExamples/zodResolverTs.ts
@@ -21,7 +21,7 @@ const App = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <input {...register("name")} />
-      <input {...register("age")} type="number" />
+      <input {...register("age", { valueAsNumber: true })} type="number" />
       <input type="submit" />
     </form>
   );


### PR DESCRIPTION
Hi,

in the zod resolver examples on the following page https://react-hook-form.com/api/useform/ it's not possible to run the code because the "age" field goes in error with the following message: `Expected number, received string`.
To resolve the error I added the `{ valueAsNumber: true }` in the age input.

There is the same error in the codesanbox examples, also in these examples, there is another error, the name type is a number instead a string. Is there a way to fix them? If you let me know I can do that.

Thanks