### PR TITLE
Fix typo in navigation

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -288,7 +288,7 @@ export default function Nav() {
                     rel="noopener noreferrer"
                     className={styles.linkExternal}
                   >
-                    <b>BEEKAI</b> From Builder{" "}
+                    <b>BEEKAI</b> Form Builder{" "}
                     <img src={openLink} alt="BEEKAI Form Builder" />
                   </a>
 


### PR DESCRIPTION
`FROM` -> `FORM` in Beekai Form Builder navigation item.