### PR TITLE
fix: light background on mobile menu

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -40,7 +40,7 @@
 }
 
 :global(.light) .actionButtonGroup {
-  background: none;
+  background: var(--color-blue);
 }
 
 .actionButtonGroup a {
@@ -194,11 +194,8 @@ a.legacyLink {
     padding: 13px 8px;
   }
 
-  :global(.dark) > .actionButtonGroup {
-    background: var(--color-button-blue);
+  :global(.light) .actionButtonGroup {
     background: none;
-    box-shadow: none;
-    color: white;
   }
 
   .actionButtonGroup a {


### PR DESCRIPTION
Light theme navbar has a global style none applied when it should only be done if screen size is 1024px +

![image](https://github.com/react-hook-form/documentation/assets/6351530/862e4f17-41f7-4a8d-861a-5f380ed3f2d6)
