### PR TITLE
fix: remove openbase link

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -57,14 +57,6 @@ export default function Footer() {
           rel="noreferrer noopener"
         >
           @github
-        </a>{" "}
-        |{" "}
-        <a
-          href="https://openbase.io/js/react-hook-form"
-          target="_blank"
-          rel="noreferrer noopener"
-        >
-          Feedback
         </a>
       </p>
       <p


### PR DESCRIPTION
Remove the Openbase feedback link in the footer since they have shut down their service
<br />
![image](https://github.com/react-hook-form/documentation/assets/43630681/917716b8-7f3d-4c4e-ae67-f3a5c77e9156)
