### PR TITLE
fix: adding redirect logic from api pages

### DIFF
--- a/src/pages/api/[[...route]].ts
+++ b/src/pages/api/[[...route]].ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next"
+
+// TODO: Move to 301 after testing in production. Browser aggressively caches 301 requests and can cause issues.
+export default function handler(
+  { query }: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (typeof query.route === "string") {
+    return res.redirect(307, `/docs/${query.route}`)
+  }
+
+  if (Array.isArray(query.route)) {
+    const redirect = query.route.join("/")
+
+    return res.redirect(307, `/docs/${redirect}`)
+  }
+
+  res.redirect(307, "/docs")
+}


### PR DESCRIPTION
Adds a catch all api route for anything under "/api"

https://nextjs.org/docs/pages/building-your-application/routing/api-routes#optional-catch-all-api-routes

TODO: move to 301 in the future. Right now keeping at 307 since I had issues in testing if I messed up since it would have a wrong redirect.