### PR TITLE
fix: if docsearch is not loading, don't crash page

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -12,7 +12,7 @@ const Search = () => {
   const searchRef = useRef(null)
 
   useEffect(() => {
-    window.docsearch({
+    window?.docsearch?.({
       appId: "Z2CKVVT2QA",
       apiKey: "c56a3f265ffbf85c2c654f865cb09164",
       indexName: "react-hook-form",

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,5 +1,5 @@
 interface Window {
-  docsearch: any
+  docsearch?: any
 }
 
 declare module "*.mdx" {


### PR DESCRIPTION
Upgrading to https://docsearch.algolia.com/docs/DocSearch-v3 would be more ideal than this fix but it will prevent this script from crashing the page.

Tested by removing docsearch script from Head and loading the page.

Before, it would crash the page. Now, search is disabled instead.