### PR TITLE
Fix typo in npm install command.

### DIFF
--- a/src/content/get-started.mdx
+++ b/src/content/get-started.mdx
@@ -642,7 +642,7 @@ We also support schema-based form validation with [Yup](https://github.com/jquen
 **Step 1:** Install `Yup` into your project.
 
 ```bash copy
-npm install @hookform/resolvers yupCopy
+npm install @hookform/resolvers yup
 ```
 
 **Step 2:** Prepare your schema for validation and register inputs with React Hook Form.


### PR DESCRIPTION
Fixed the the typo in the npm install instruction from 'yupcopy ' to 'yup'. This fix ensures accurate installation of yup package.