### PR TITLE
fix: make start script reference dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "format": "prettier --write \"src/**/*.{ts,tsx,mdx}\"",
     "lint": "next lint --fix",
     "now-build": "npm run build",
-    "start": "npm run develop",
+    "start": "npm run dev",
     "typecheck": "tsc --noEmit"
   },
   "husky": {


### PR DESCRIPTION
The start script referenced a nonexistent `develop` script. Now updated to `dev` script.