### PR TITLE
fix: devtools dependency stripped out in prod

### DIFF
--- a/src/components/DevTools.tsx
+++ b/src/components/DevTools.tsx
@@ -15,9 +15,13 @@ import getStartedStyle from "./GetStarted.module.css"
 import styles from "./DevTools.module.css"
 import ClipBoard from "./ClipBoard"
 import dynamic from "next/dynamic"
+import type { DevtoolUIProps } from "@hookform/devtools/dist/devToolUI"
 
-const DevTool = dynamic(
-  () => import("@hookform/devtools").then((mod) => mod.DevTool),
+const DevTool = dynamic<DevtoolUIProps>(
+  () =>
+    import("@hookform/devtools/dist/index.cjs.development").then(
+      (mod) => mod.DevTool
+    ),
   {
     ssr: false,
   }


### PR DESCRIPTION
## Problem
Oversight on my part.

Devtools was working in local development because process.env === "DEVELOPMENT"

When deploying to prod, DevTools became a no-op and does not render. https://github.com/react-hook-form/devtools/blob/master/rollup/writeCjsEntryFile.js

This changes the import path to use the development bundle and still appear in prod. 

This change got lost in trying to use the dynamic import as suggested by devtools repo for it to work in nextjs.

## Testing
* npm run dev - Worked as expected in development
* npm run build && npm run start - Build + start mimicks prod behaviour. Worked when importing the development bundle since it doesn't become a no-op 
