### PR TITLE
fix: update typo in get started example

### DIFF
--- a/src/content/get-started.mdx
+++ b/src/content/get-started.mdx
@@ -115,7 +115,7 @@ enum GenderEnum {
 }
 
 interface IFormInput {
-  firstName: String
+  firstName: string
   gender: GenderEnum
 }
 


### PR DESCRIPTION
Fix TS typo in `src/content/get-started.mdx`

_before_
```ts
firstName: String
```

_after_
```
firstName: string
```