### PR TITLE
fix: correct useForm defaultValues type documentation

### DIFF
--- a/src/content/docs/useform.mdx
+++ b/src/content/docs/useform.mdx
@@ -123,7 +123,7 @@ This option allows you to configure the validation strategy before a user submit
 
 This option allows you to configure validation strategy when inputs with errors get re-validated **after** a user submits the form (`onSubmit` event and [`handleSubmit`](/docs/useform/handlesubmit) function executed). By default, re-validation occurs during the input change event.
 
-#### defaultValues: <TypeText>`FieldValues | Promise<FieldValues>`</TypeText> {#defaultValues}
+#### defaultValues: <TypeText>`FieldValues | () => Promise<FieldValues>`</TypeText> {#defaultValues}
 
 ---
 


### PR DESCRIPTION
Setting default props asynchronously requires a function to return a promise, not just the promise. See [these lines](https://github.com/react-hook-form/react-hook-form/blob/011fad503cc8d4543892f8e847b9bd58c1d9400f/src/types/form.ts#L98-L108) for evidence. This is documented incorrectly but is fixed by this pull request.

_Note: [The async defaultValues function includes a parameter](https://github.com/react-hook-form/react-hook-form/blob/011fad503cc8d4543892f8e847b9bd58c1d9400f/src/types/form.ts#L99C3-L99C21) [which appears to never be used](https://github.com/react-hook-form/react-hook-form/blob/011fad503cc8d4543892f8e847b9bd58c1d9400f/src/logic/createFormControl.ts#L1262). So it would be misleading to include that parameter in the type documentation._