### PR TITLE
use `useImperativeHandle` to share Refs

### DIFF
--- a/src/content/faqs.mdx
+++ b/src/content/faqs.mdx
@@ -127,7 +127,7 @@ React Hook Form needs a `ref` to collect the input value. However, you may want 
 <TabGroup buttonLabels={["TS", "JS"]}>
 
 ```typescript copy
-import React, { useRef } from "react"
+import { useRef, useImperativeHandle } from "react"
 import { useForm } from "react-hook-form"
 
 type Inputs = {
@@ -137,21 +137,21 @@ type Inputs = {
 
 export default function App() {
   const { register, handleSubmit } = useForm<Inputs>()
-  const firstNameRef = useRef<HTMLInputElement | null>(null)
-  const onSubmit = (data) => console.log(data)
+  const firstNameRef = useRef<HTMLInputElement>(null)
+  const onSubmit = (data: Inputs) => console.log(data)
   const { ref, ...rest } = register("firstName")
+  const onClick = () => {
+    firstNameRef.current!.value = ""
+  }
+
+  useImperativeHandle(ref, () => firstNameRef.current)
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input
-        {...rest}
-        name="firstName"
-        ref={(e) => {
-          ref(e)
-          firstNameRef.current = e // you can still assign to ref
-        }}
-      />
-
+      <input {...rest} ref={firstNameRef} />
+      <button type="button" onClick={onClick}>
+        clear
+      </button>
       <button>Submit</button>
     </form>
   )
@@ -159,7 +159,7 @@ export default function App() {
 ```
 
 ```javascript copy
-import React, { useRef } from "react"
+import { useRef, useImperativeHandle } from "react"
 import { useForm } from "react-hook-form"
 
 export default function App() {
@@ -167,18 +167,19 @@ export default function App() {
   const firstNameRef = useRef(null)
   const onSubmit = (data) => console.log(data)
   const { ref, ...rest } = register("firstName")
+  const onClick = () => {
+    firstNameRef.current!.value = ""
+  }
+
+  useImperativeHandle(ref, () => firstNameRef.current)
+
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <input
-        {...rest}
-        name="firstName"
-        ref={(e) => {
-          ref(e)
-          firstNameRef.current = e // you can still assign to ref
-        }}
-      />
-
+      <input {...rest} ref={firstNameRef} />
+      <button type="button" onClick={onClick}>
+        clear
+      </button>
       <button>Submit</button>
     </form>
   )


### PR DESCRIPTION
**Description:**

This PR adds an enhancement to the React Hook Form documentation by demonstrating how to share a ref using the `useImperativeHandle` hook. The shared ref is used to clear the input value when a user clicks on a "clear" button.

**Changes Made:**

- Added a code snippet in both TypeScript and JavaScript that showcases the usage of `useImperativeHandle` to share a ref.
- Created a functional component (`App`) that utilizes `useForm` from `react-hook-form`.
- Created a `ref` using `useRef` to reference the input element.
- Defined an `onSubmit` function to handle the form submission.
- Extracted the `ref` and other properties from the `register` function for the "firstName" input field.
- Implemented an `onClick` function that clears the value of the input element when the "clear" button is clicked.
- Used `useImperativeHandle` to share the `ref` with the parent or other components.
- Rendered the form, input field, and buttons, passing the necessary props.

**Testing Done:**

- Tested the code locally to ensure the "clear" button successfully clears the input value.
- Verified that the form submission and console logging of the form data work as expected.
- [React Hook Form Playground (forked) - CodeSandbox](https://codesandbox.io/s/react-hook-form-playground-forked-cys64z?file=/src/App.js) 
