### PR TITLE
docs: fix typo, replace 'recommend' with 'recommended' in documentation 

### DIFF
--- a/src/components/ApiRefTable.tsx
+++ b/src/components/ApiRefTable.tsx
@@ -732,7 +732,7 @@ register('test[0]firstName'); // ❌`}
           <li>
             <p>
               Changing the name on each render will result in new inputs being
-              registered. It's recommend to keep static names for each
+              registered. It's recommended to keep static names for each
               registered input.
             </p>
           </li>

--- a/src/components/UseFieldArrayContent.tsx
+++ b/src/components/UseFieldArrayContent.tsx
@@ -74,7 +74,7 @@ export default function UseFieldArrayContent({ api }: { api: any }) {
           </p>
         </li>
         <li>
-          <p>It's recommend to not stack actions one after another.</p>
+          <p>It's recommended to not stack actions one after another.</p>
           <CodeArea
             withOutCopy
             rawData={`

--- a/src/content/docs/useform/watch.mdx
+++ b/src/content/docs/useform/watch.mdx
@@ -32,7 +32,7 @@ This method will watch specified inputs and return their values. It is useful to
 
 <Admonition type="important" title="Rules">
 
-- When `defaultValue` is not defined, the first render of `watch` will return `undefined` because it is called before `register`. It's **recommend** to provide `defaultValues` at `useForm` to avoid this behaviour, but you can set the inline `defaultValue` as the second argument.
+- When `defaultValue` is not defined, the first render of `watch` will return `undefined` because it is called before `register`. It's **recommended** to provide `defaultValues` at `useForm` to avoid this behaviour, but you can set the inline `defaultValue` as the second argument.
 - When both `defaultValue` and `defaultValues` are supplied, `defaultValue` will be returned.
 - This API will trigger re-render at the root of your app or form, consider using a callback or the [useWatch](/docs/usewatch) api if you are experiencing performance issues.
 - `watch` result is optimised for render phase instead of `useEffect`'s deps, to detect value update you may want to use an external custom hook for value comparison.


### PR DESCRIPTION
This commit addresses a typo in the documentation found in the following files:

1) ApiRefTable.tsx
2) useForm/watch.mdx
3) UseFieldArrayContent.tsx

The word 'recommend' was replaced with 'recommended' in 'it's recommended' for consistency and accuracy throughout the documentation. This resolves the issue raised in #1032.