### PR TITLE
Correctly link to lodash get documentation

### DIFF
--- a/src/content/advanced-usage.mdx
+++ b/src/content/advanced-usage.mdx
@@ -261,7 +261,7 @@ Error messages are visual feedback to our users when there are issues with their
 
 - #### Lodash `get`
 
-  If your project is using [lodash](https://lodash.com), then you can leverage the lodash `[get](https://lodash.com/docs/4.17.15#get)` function. Eg:
+  If your project is using [lodash](https://lodash.com), then you can leverage the lodash [get](https://lodash.com/docs/4.17.15#get) function. Eg:
 
   `get(errors, 'firstName.message')`
 


### PR DESCRIPTION
The link was originally rendered in a code block. It now renders as an actual link