### PR TITLE
Add section on behaviour of values prop in combination with defaultValues prop

### DIFF
--- a/src/content/docs/useform.mdx
+++ b/src/content/docs/useform.mdx
@@ -170,7 +170,7 @@ useForm({
 
 ---
 
-The `values` prop will react to changes and update the form values, which is useful when your form needs to be updated by external state or server data. The `values` prop will overwrite `defaultValues`, unless `resetOptions: { keepDefaultValues: true }` is also set for `useForm`.
+The `values` prop will react to changes and update the form values, which is useful when your form needs to be updated by external state or server data. The `values` prop will overwrite the `defaultValues` prop, unless `resetOptions: { keepDefaultValues: true }` is also set for `useForm`.
 
 ```javascript copy
 

--- a/src/content/docs/useform.mdx
+++ b/src/content/docs/useform.mdx
@@ -172,7 +172,6 @@ useForm({
 
 The `values` prop will react to changes and update the form values, which is useful when your form needs to be updated by external state or server data. The `values` prop will overwrite the `defaultValues` prop, unless `resetOptions: { keepDefaultValues: true }` is also set for `useForm`.
 
-```javascript copy
 
 ```javascript copy
 // set default value sync

--- a/src/content/docs/useform.mdx
+++ b/src/content/docs/useform.mdx
@@ -170,7 +170,9 @@ useForm({
 
 ---
 
-The `values` props will react to changes and update the form values, which is useful when your form needs to be updated by external state or server data.
+The `values` prop will react to changes and update the form values, which is useful when your form needs to be updated by external state or server data. The `values` prop will overwrite `defaultValues`, unless `resetOptions: { keepDefaultValues: true }` is also set for `useForm`.
+
+```javascript copy
 
 ```javascript copy
 // set default value sync


### PR DESCRIPTION
Hello, it might be helpful to clarify how `values` and `defaultValues` work when both props are used with the `useForm` hook. This behaviour seems to have tripped up [another user before](https://github.com/react-hook-form/react-hook-form/issues/10954).
I observed the behaviour when using `defaultData` to store default values and `values` for storing the latest form values that were previously submitted. When trying to reset the form via `reset` or resetting the field via `resetField` `values` would be used as default values instead of `defaultValues` unless `resetOptions: { keepDefaultValues: true }` was used.

Cheers