### PR TITLE
Fix handleSubmit type documentation.

### DIFF
--- a/src/content/docs/useform/handlesubmit.mdx
+++ b/src/content/docs/useform/handlesubmit.mdx
@@ -4,7 +4,7 @@ description: Ready to send to the server
 sidebar: apiLinks
 ---
 
-## \</> `handleSubmit:` <TypeText>`((data: Object, e?: Event) => Promise<void>, (errors: Object, e?: Event) => void) => Promise<void>`</TypeText>
+## \</> `handleSubmit:` <TypeText>`((data: Object, e?: Event) => Promise<void>, (errors: Object, e?: Event) => Promise<void>) => Promise<void>`</TypeText>
 
 This function will receive the form data if form validation is successful.
 


### PR DESCRIPTION
Based on RHF types
UseFormHandleSubmit: https://github.com/react-hook-form/react-hook-form/blob/master/src/types/form.ts#L626
SubmitErrorHandler: https://github.com/react-hook-form/react-hook-form/blob/master/src/types/form.ts#L81

handleSubmit method type should be descripted as follows:

handleSubmit: (
   (data: Object, e?: Event) => Promise<void>,
   (errors: Object, e?: Event) => Promise<void>
) => Promise<void>