### PR TITLE
Extend documentation with section on new transformed values type feature of `useForm` and `SubmitHandler`

### DIFF
--- a/src/content/ts.mdx
+++ b/src/content/ts.mdx
@@ -56,6 +56,8 @@ export default function App() {
 
 ## \</> SubmitHandler {#SubmitHandler}
 
+This type defines the shape of the data that is used in the submit handler. By default the type will be the same as the type used for `useForm` {#UseFormReturn}. When form data gets transformed via resolvers, an additional type is used as the third type parameter for `useForm`. This type should also be used for the submit handler so that the correct shape of the transformed form data is used inside the submit handler.
+
 ```typescript copy sandbox="https://codesandbox.io/s/react-hook-form-handlesubmit-ts-v7-z9z0g"
 import React from "react"
 import { useForm, SubmitHandler } from "react-hook-form"
@@ -129,7 +131,8 @@ export default function App() {
 ```typescript copy
 export type UseFormReturn<
   TFieldValues extends FieldValues = FieldValues,
-  TContext = any
+  TContext = any,
+  TTransformedValues extends FieldValues = TFieldValues
 > = {
   watch: UseFormWatch<TFieldValues>
   getValues: UseFormGetValues<TFieldValues>


### PR DESCRIPTION
Hello, the `useForm` hooks and `SubmitHandler` method seem to have gotten updates to work better with resolvers that transform input data and return said data with different shapes, for example `z.boolean().transform((value) => (value ? "Yes" : "No")),`, which transforms the field value from boolean to the union type "Yes" | "No". 
This was first discovered here: https://github.com/react-hook-form/documentation/issues/1078. As suggested in that thread, it might be helpful to extend the documentation to include this this new feature.

Cheers