### PR TITLE
style(nav): fix X icon visibility issue

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -15,9 +15,12 @@
 
 .icon svg {
   height: 16px;
-  fill: white;
   transition: 0.3s all;
   margin-top: 6px;
+}
+
+:global(.dark) .icon svg {
+  fill: white;
 }
 
 .icon svg:hover {
@@ -153,6 +156,10 @@ a.legacyLink {
 }
 
 @media (min-width: 1040px) {
+  .icon svg {
+    fill: white;
+  }
+
   .mobileOnly {
     display: none;
   }


### PR DESCRIPTION
Fixes #1091
Now X icon is visible on both light and dark mode on mobile version.
![Screenshot 2024-10-31 at 15 35 41](https://github.com/user-attachments/assets/6eeb3c6d-2d89-4cc5-b1f7-5a40fe257fb1)
![Screenshot 2024-10-31 at 15 35 57](https://github.com/user-attachments/assets/d0dd024c-65de-463d-b3dc-020997669c87)
