### PR TITLE
fix(BuilderPage): use css variables for background and icon border color

### DIFF
--- a/src/components/BuilderPage.module.css
+++ b/src/components/BuilderPage.module.css
@@ -9,6 +9,12 @@
   -webkit-overflow-scrolling: touch;
 }
 
+.builder {
+  overflow: auto;
+  height: 100vh;
+  background: var(--color-background);
+}
+
 .pageWrapper {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));

--- a/src/components/BuilderPage.tsx
+++ b/src/components/BuilderPage.tsx
@@ -433,14 +433,7 @@ function BuilderPage({
       }}
       render={({ style }) => (
         <main className={styles.root} style={style}>
-          <div
-            id="builder"
-            style={{
-              overflow: "auto",
-              height: "100vh",
-              background: colors.primary,
-            }}
-          >
+          <div id="builder" className={styles.builder}>
             <button
               className={styles.closeButton}
               aria-label="close builder"

--- a/src/components/Popup.module.css
+++ b/src/components/Popup.module.css
@@ -14,7 +14,7 @@
 }
 
 .icon {
-  border: 1px solid white;
+  border: 1px solid var(--color-text);
   margin-left: 0;
   margin-right: 5px;
 }


### PR DESCRIPTION
Close #1096 

I encountered the above linked issue when using the form builder in light mode.
To fix the issue I used `var(--color-background)` as background of the form-builder element
and `var(--text-color)` as border-color for the icons

<details><summary>This is the result:</summary>
<p>

<img width="1205" alt="image" src="https://github.com/user-attachments/assets/ea830162-4489-404c-b653-16af46dc01c1" />

</p>
</details> 




