### PR TITLE
fix(SideMenu): minor CSS tweak

### DIFF
--- a/src/components/Menu/SideMenu.module.css
+++ b/src/components/Menu/SideMenu.module.css
@@ -107,6 +107,7 @@
   font-size: 12px;
   top: 2px;
   display: inline-table;
+  flex-shrink: 0;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
Prevents code icon in side menu item to be shrunk by a line-overflowing text.

Before:
![image](https://github.com/user-attachments/assets/ace4be43-c732-4af8-bc9a-88f93af3c5de)


After:
![image](https://github.com/user-attachments/assets/e70e889b-f148-4645-b336-abe207eecc54)
