### PR TITLE
docs: Add `SubmitErrorHandler` type to `ts.mdx`

### DIFF
--- a/src/content/docs/useform/handlesubmit.mdx
+++ b/src/content/docs/useform/handlesubmit.mdx
@@ -110,7 +110,7 @@ import { useForm } from "react-hook-form";
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 function App() {
-  const { register, handleSubmit, formState: { errors }, formState } = useForm();
+  const { register, handleSubmit, formState: { errors } } = useForm();
   const onSubmit = async data => {
     await sleep(2000);
     if (data.username === "bill") {

--- a/src/content/docs/useform/handlesubmit.mdx
+++ b/src/content/docs/useform/handlesubmit.mdx
@@ -56,7 +56,7 @@ This function will receive the form data if form validation is successful.
 
 ```typescript copy sandbox="https://codesandbox.io/s/react-hook-form-handlesubmit-ts-v7-lcrtu"
 import React from "react"
-import { useForm, SubmitHandler } from "react-hook-form"
+import { useForm, SubmitHandler, SubmitErrorHandler } from "react-hook-form"
 
 type FormValues = {
   firstName: string
@@ -67,6 +67,7 @@ type FormValues = {
 export default function App() {
   const { register, handleSubmit } = useForm<FormValues>()
   const onSubmit: SubmitHandler<FormValues> = (data) => console.log(data)
+  const onError: SubmitErrorHandler<FormValues> = (errors) => console.log(errors)
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/content/ts.mdx
+++ b/src/content/ts.mdx
@@ -103,8 +103,8 @@ export default function App() {
 
   return (
     <form onSubmit={handleSubmit(onSubmit, onError)}>
-      <input {...register("firstName")} />
-      <input {...register("lastName")} />
+      <input {...register("firstName"), { required: true }} />
+      <input {...register("lastName"), { minLength: 2 }} />
       <input type="email" {...register("email")} />
 
       <input type="submit" />

--- a/src/content/ts.mdx
+++ b/src/content/ts.mdx
@@ -84,6 +84,37 @@ export default function App() {
 
 ---
 
+## \</> SubmitErrorHandler {#SubmitErrorHandler}
+
+```typescript copy
+import React from "react"
+import { useForm, SubmitHandler, SubmitErrorHandler } from "react-hook-form"
+
+type FormValues = {
+  firstName: string
+  lastName: string
+  email: string
+}
+
+export default function App() {
+  const { register, handleSubmit } = useForm<FormValues>()
+  const onSubmit: SubmitHandler<FormValues> = (data) => console.log(data)
+  const onError: SubmitErrorHandler<FormValues> = (errors) => console.log(errors);
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit, onError)}>
+      <input {...register("firstName")} />
+      <input {...register("lastName")} />
+      <input type="email" {...register("email")} />
+
+      <input type="submit" />
+    </form>
+  )
+}
+```
+
+---
+
 ## \</> Control {#Control}
 
 ```typescript copy sandbox="https://codesandbox.io/s/control-2mg07"


### PR DESCRIPTION
- I added `SubmitErrorHandler` type to `ts.mdx`.
- In the synchronous example of `handleSubmit`, `onError` was only set for the JavaScript example, so I added it to the TypeScript example as well.  
- Removed unused variables in the asynchronous example.  

I wanted to add a sandbox example for `SubmitErrorHandler` type, but I was unsure if I could include my personal sandbox link. How can I add a sandbox link?
