### PR TITLE
Fix: admonition svg color in light mode

### DIFF
--- a/src/components/Admonition.module.css
+++ b/src/components/Admonition.module.css
@@ -19,6 +19,11 @@
 }
 
 .admonitionIcon svg {
+  stroke: var(--color-black);
+  fill: var(--color-black);
+}
+
+:global(.dark) .admonitionIcon svg {
   stroke: rgb(253, 253, 254);
   fill: rgb(253, 253, 254);
 }


### PR DESCRIPTION
Addressing: https://github.com/react-hook-form/documentation/issues/1124

Before:
![image](https://github.com/user-attachments/assets/7a087632-b4ef-4131-87a7-b4e6329db54b)

After:
![image](https://github.com/user-attachments/assets/a1e5dcd2-e76f-46b4-898c-0541cf64947e)
