### PR TITLE
docs: Add SubmitErrorHandler to typescript example so it matches the javascript example

### DIFF
--- a/src/content/docs/useform/handlesubmit.mdx
+++ b/src/content/docs/useform/handlesubmit.mdx
@@ -70,7 +70,7 @@ export default function App() {
   const onError: SubmitErrorHandler<FormValues> = (errors) => console.log(errors)
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit, onError)}>
       <input {...register("firstName")} />
       <input {...register("lastName")} />
       <input type="email" {...register("email")} />


### PR DESCRIPTION
When browsing the docs I noticed that the TS and JS Sync examples in the docs for [`handleSubmit`](https://react-hook-form.com/docs/useform/handlesubmit) were mismatched. 

Specifically, even though an `onError`  handler is defined in the TS example, it isn't passed to `handleSubmit`.

Another idea might be to update both the javascript and typescript examples to include some validation rules, like this one 
```typescript copy
import React from "react"
import { useForm, SubmitHandler, SubmitErrorHandler } from "react-hook-form"

type FormValues = {
  firstName: string
  lastName: string
  email: string
}

export default function App() {
  const { register, handleSubmit } = useForm<FormValues>()
  const onSubmit: SubmitHandler<FormValues> = (data) => console.log(data)
  const onError: SubmitErrorHandler<FormValues> = (errors) => console.log(errors);

  return (
    <form onSubmit={handleSubmit(onSubmit, onError)}>
      <input {...register("firstName"), { required: true }} />
      <input {...register("lastName"), { minLength: 2 }} />
      <input type="email" {...register("email")} />

      <input type="submit" />
    </form>
  )
}
```
from the[ TS section](https://react-hook-form.com/ts)
