### PR TITLE
Add `onError` to TypeScript code block `handleSubmit` function

### DIFF
--- a/src/content/docs/useform/handlesubmit.mdx
+++ b/src/content/docs/useform/handlesubmit.mdx
@@ -69,7 +69,7 @@ export default function App() {
   const onError: SubmitErrorHandler<FormValues> = (errors) => console.log(errors)
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit, onError)}>
       <input {...register("firstName")} />
       <input {...register("lastName")} />
       <input type="email" {...register("email")} />


### PR DESCRIPTION
In this `tsx` code block we define `onError`, but we never pass it to the `handleSubmit` function.

In the `jsx` code block we pass the `onError` properly.