### PR TITLE
Fix watch overload types

### DIFF
--- a/src/content/docs/useform/watch.mdx
+++ b/src/content/docs/useform/watch.mdx
@@ -12,8 +12,8 @@ This method will watch specified inputs and return their values. It is useful to
 
 This function mainly serves **two purposes**:
 
-- <TypeText>`watch(name: string, defaultValue?): unknown`</TypeText>
-- <TypeText>`watch(names: string[], defaultValue?): {[key:string]: unknown}`</TypeText>
+- <TypeText>`watch(name: string, defaultValue?: unknown): unknown`</TypeText>
+- <TypeText>`watch(names: string[], defaultValue?: {[key:string]: unknown}): unknown[]`</TypeText>
 - <TypeText>`watch(): {[key:string]: unknown}`</TypeText>
 
 The explanation of each of these four overloads follows below.


### PR DESCRIPTION
This PR fixes the watch() function documentation, which previously listed incorrect overloads.

**Before**
```ts
watch(name: string, defaultValue?): unknown
watch(names: string[], defaultValue?): {[key:string]: unknown}
watch(): {[key:string]: unknown}
```
**After**
```ts
watch(name: string, defaultValue?: unknown): unknown
watch(names: string[], defaultValue?: {[key:string]: unknown}): unknown[]
watch(): {[key:string]: unknown}
```


