### PR TITLE
fix sticky sidebar

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -848,7 +848,7 @@ pre[class*="language-"] {
 }
 
 .pageTransition {
-  animation: page-enter 0.45s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: page-enter 0.45s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
  ## Summary

  This fixes the sidebar not staying sticky on pages outside `/docs/*`.

  The page animation was keeping a transform active after it finished, which
  interfered with the sidebar’s fixed positioning. Removing the animation fill mode
  keeps the entrance animation smooth while allowing the sidebar to remain sticky.

  ## Verification

  - Tested the sidebar while scrolling
  - Prettier passed
  - TypeScript passed
  - Production build passed